### PR TITLE
[update] fix grammar in group guides

### DIFF
--- a/docs/api/data_collection/change_event.md
+++ b/docs/api/data_collection/change_event.md
@@ -14,7 +14,7 @@ description: You can learn about the change event of data collection in the docu
 
 ~~~jsx
 change: (
-    id?: string, 
+    id?: string,
     status?: "add" | "update" | "delete" | "load"
     updatedItem?: object
 ) => void;

--- a/docs/api/data_collection/copy_method.md
+++ b/docs/api/data_collection/copy_method.md
@@ -15,7 +15,7 @@ description: You can learn about the copy method of data collection in the docum
 ~~~jsx
 copy(
     id: string | number | array,
-    index: number, 
+    index: number,
     target?: object
 ): string | number | array;
 ~~~

--- a/docs/api/data_collection/eachchild_method.md
+++ b/docs/api/data_collection/eachchild_method.md
@@ -14,8 +14,8 @@ description: You can learn about the eachChild method of data collection in the 
 
 ~~~jsx
 eachChild(
-    id: string | number, 
-    callback: function, 
+    id: string | number,
+    callback: function,
     isTree?: boolean
 ): void;
 ~~~
@@ -24,7 +24,7 @@ eachChild(
 
 - `id` - (required) the id of the item
 - `callback` - (required) a callback function that will be applied to each child of the item
-- `isTree` - (optional) defines, whether the function should iterate through all children (of any level) of the specified item. If *false*, the function will iterate only through the first-level children of the item; *true* by default.
+- `isTree` - (optional) defines whether the function should iterate through all children (of any level) of the specified item. If *false*, the function will iterate only through the first-level children of the item; *true* by default.
 
 ### Example
 

--- a/docs/api/data_collection/eachparent_method.md
+++ b/docs/api/data_collection/eachparent_method.md
@@ -14,8 +14,8 @@ description: You can learn about the eachParent method of data collection in the
 
 ~~~jsx
 eachParent(
-    id: string | number, 
-    callback: function, 
+    id: string | number,
+    callback: function,
     self?: boolean
 ): void
 ~~~

--- a/docs/api/data_collection/exists_method.md
+++ b/docs/api/data_collection/exists_method.md
@@ -32,5 +32,5 @@ const diagram = new dhx.Diagram("diagram_container", {
 });
 diagram.data.parse(data);
 
-const shape = diagram.data.exists("1"); 
+const shape = diagram.data.exists("1");
 ~~~

--- a/docs/api/data_collection/filter_event.md
+++ b/docs/api/data_collection/filter_event.md
@@ -8,7 +8,7 @@ description: You can learn about the filter event of data collection in the docu
 
 ### Description
 
-@short: fires after filtering a data collection 
+@short: fires after filtering a data collection
 
 ### Usage
 

--- a/docs/api/data_collection/filter_method.md
+++ b/docs/api/data_collection/filter_method.md
@@ -14,7 +14,7 @@ description: You can learn about the filter method of data collection in the doc
 
 ~~~jsx
 filter(
-    rule?: function, 
+    rule?: function,
     config?: {
         id?: string,
         add?: boolean,

--- a/docs/api/data_collection/findall_method.md
+++ b/docs/api/data_collection/findall_method.md
@@ -30,7 +30,7 @@ findAll(rule: function): array;
 
 ### Returns
 
-The method returns an array of matching item objects 
+The method returns an array of matching item objects
 
 ### Example
 

--- a/docs/api/data_collection/getfilters_method.md
+++ b/docs/api/data_collection/getfilters_method.md
@@ -8,7 +8,7 @@ description: You can learn about the getFilters method of data collection in the
 
 ### Description
 
-@short: Returns an object with the applied filters 
+@short: Returns an object with the applied filters
 
 ### Usage
 
@@ -23,7 +23,7 @@ getFilters({ permanent?: boolean }): object;
 ### Returns
 
 The method returns an object with the applied filters, where:
-- `key` - the id of a filter 
+- `key` - the id of a filter
 - `value` - an object with the [`rule` and `config` properties](api/data_collection/filter_method.md#parameters)
 
 ### Example
@@ -33,7 +33,7 @@ const diagram = new dhx.Diagram("diagram_container", {
     // configuration settings
 });
 diagram.data.parse(data);
-    
+
 const filters = diagram.data.getFilters(); // gets all the applied filters
 console.log(filters);
 ~~~

--- a/docs/api/data_collection/load_method.md
+++ b/docs/api/data_collection/load_method.md
@@ -14,7 +14,7 @@ description: You can learn about the load method of data collection in the docum
 
 ~~~jsx
 load(
-    url: string | object, 
+    url: string | object,
     driver?: object | string
 ): promise;
 ~~~

--- a/docs/api/data_collection/move_method.md
+++ b/docs/api/data_collection/move_method.md
@@ -14,8 +14,8 @@ description: You can learn about the move method of data collection in the docum
 
 ~~~jsx
 move(
-    id: string | number | array, 
-    index: number, 
+    id: string | number | array,
+    index: number,
     target?: object
 ): string | number | array;
 ~~~

--- a/docs/api/data_collection/parse_method.md
+++ b/docs/api/data_collection/parse_method.md
@@ -27,8 +27,8 @@ parse(
     data: object[]; // an array of all shapes and connections
     ~~~
     - for the PERT Diagram mode it is an object with:
-      -  the `data` array (for shapes: `"task"`, `"milestone"`, `"project"`) 
-      -  the `links` array (for connections between shapes) 
+      -  the `data` array (for shapes: `"task"`, `"milestone"`, `"project"`)
+      -  the `links` array (for connections between shapes)
     ~~~jsx
     {
         data: object[]; // an array of shapes (tasks, milestones, projects)
@@ -65,8 +65,8 @@ const data = [
     { id: "1-3", from: "1", to: "3", type: "line" }
 ];
 
-const diagram = new dhx.Diagram("diagram_container", { 
-    type: "org" 
+const diagram = new dhx.Diagram("diagram_container", {
+    type: "org"
 });
 
 diagram.data.parse(data);
@@ -99,6 +99,6 @@ diagram.data.parse(dataset);
 
 **Related articles**:  [Loading and storing data](guides/loading_data.md)
 
-**Related samples**: 
+**Related samples**:
 - [Diagram. Org chart mode. Basic initialization](https://snippet.dhtmlx.com/5ign6fyy)
 - [Diagram. PERT chart. Initialization](https://snippet.dhtmlx.com/4h5fi7xd)

--- a/docs/api/data_collection/serialize_method.md
+++ b/docs/api/data_collection/serialize_method.md
@@ -8,21 +8,21 @@ description: You can learn about the serialize method of data collection in the 
 
 ### Description
 
-@short: Exports the current diagram data 
+@short: Exports the current diagram data
 
 ### Usage
 
 ~~~jsx
-serialize(): object[] | { data: object[]; links: object[] }; 
+serialize(): object[] | { data: object[]; links: object[] };
 ~~~
 
 ### Returns
 
 Depending on the diagram mode, the method returns:
 
-- `object[]` - (for the default, org chart and mindmap Diagram modes) an array of objects for each item and link from Diagram 
+- `object[]` - (for the default, org chart and mindmap Diagram modes) an array of objects for each item and link from Diagram
 - `{ data: object[]; links: object[] }` - (for the PERT Diagram mode) an object with:
-  - the `data` array of objects (for shapes: `"task"`, `"milestone"`, `"project"`) 
+  - the `data` array of objects (for shapes: `"task"`, `"milestone"`, `"project"`)
   - the `links` array of objects (for connections between shapes)
 
 ### Example

--- a/docs/api/data_collection/update_method.md
+++ b/docs/api/data_collection/update_method.md
@@ -18,7 +18,7 @@ The method can't be used to change the *id* or *type* of the item
 
 ~~~jsx
 update(
-    id: string | number, 
+    id: string | number,
     newItem: object
 ): void;
 ~~~

--- a/docs/api/diagram/addshape_method.md
+++ b/docs/api/diagram/addshape_method.md
@@ -1,10 +1,10 @@
 ---
-sidebar_label: addShape() 
+sidebar_label: addShape()
 title: addShape Method
 description: You can learn about the addShape method in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Diagram.
 ---
 
-# addShape() 
+# addShape()
 
 ### Description
 
@@ -14,9 +14,9 @@ The `addShape()` method can be used both in the diagram and in the editor. [Chec
 
 ### Usage
 
-~~~jsx 
+~~~jsx
 addShape(
-    type: string, 
+    type: string,
     parameters: object
 ): void;
 ~~~
@@ -28,15 +28,15 @@ addShape(
     - `template: function` - (required) the function that takes the configuration object of the shape as a parameter and returns either an HTML or SVG template
     - [`defaults: object`](shapes/custom_shape.md) - (optional) the default configuration for a created shape. See [the full list of the configuration properties of a shape](shapes/configuration_properties.md)
     - [`eventHandlers: object`](shapes/custom_shape.md#event-handlers-for-custom-shapes) - (optional) adds custom event handlers to HTML elements of the template of a shape. The `eventHandlers` object includes a set of `key:value` pairs, where:
-        - `key: string` - the name of the event. Note, that at the beginning of the event name the 'on' prefix is used (onclick, onmouseover)
-        - `value: object` - an object that contains a `key:value` pair, where 
+        - `key: string` - the name of the event. Note that the 'on' prefix is used at the beginning of the event name (onclick, onmouseover)
+        - `value: object` - an object that contains a `key:value` pair, where
           - `key` is the CSS class name that the handler will be applied to
           - `value` is a function that takes two parameters:
             - `event: object` - (required) an event object
             - `shape: object` - (required) the shape object
-         
+
         :::tip
-        **Note**, we recommend that you use different CSS classes for different custom shapes when initializing custom event handlers.
+        We recommend that you use different CSS classes for different custom shapes when initializing custom event handlers.
         :::
 
 ### Example
@@ -65,7 +65,7 @@ diagram.addShape("personal", {
                 </div>
             </div>
         </div>
-    `), 
+    `),
     defaults: {
         height: 115, width: 330,
         name: "Name and First name",

--- a/docs/api/diagram/aftercollapse_event.md
+++ b/docs/api/diagram/aftercollapse_event.md
@@ -14,7 +14,7 @@ description: You can learn about the afterCollapse event in the documentation of
 
 ~~~jsx
 afterCollapse: (
-    id: string | number, 
+    id: string | number,
     dir?: string
 ) => void;
 ~~~

--- a/docs/api/diagram/afterexpand_event.md
+++ b/docs/api/diagram/afterexpand_event.md
@@ -14,7 +14,7 @@ description: You can learn about the afterExpand event in the documentation of t
 
 ~~~jsx
 afterExpand: (
-    id: string | number, 
+    id: string | number,
     dir?: string
 ) => void;
 ~~~

--- a/docs/api/diagram/aftersubmenuopen_event.md
+++ b/docs/api/diagram/aftersubmenuopen_event.md
@@ -14,8 +14,8 @@ description: You can learn about the afterSubmenuOpen event in the documentation
 
 ~~~jsx
 afterSubmenuOpen: (
-    id: string | number, 
-    event: MouseEvent, 
+    id: string | number,
+    event: MouseEvent,
     subHeaderId?: string
 ) => void;
 ~~~

--- a/docs/api/diagram/autoplace_method.md
+++ b/docs/api/diagram/autoplace_method.md
@@ -57,7 +57,7 @@ Connector lines are aligned "from side to side".
 If `fromSide` and `toSide` are set on a link, the autoplacement algorithm will preserve those values but will not use them during placement calculation. The key properties that define links are `from` and `to`, while `fromSide` and `toSide` are calculated automatically by the algorithm.
 :::
 
-:::info 
+:::info
 To add arrows to the lines, specify `forwardArrow: "filled"` or `backArrow: "filled"` in the configuration of a [line object](lines/configuration_properties.md).
 :::
 
@@ -106,6 +106,6 @@ Shapes are arranged on imaginary circles relative to the central shape, i.e. a s
 
 **Related articles**: [Arranging shapes automatically](guides/manipulating_items.md#arranging-shapes-automatically)
 
-**Related sample**: 
+**Related sample**:
 - [Diagram. Default mode. Radial autoplacement with padding options](https://snippet.dhtmlx.com/huut0l1s)
 - [Diagram. Default mode. Autoplacement](https://snippet.dhtmlx.com/f3uekgjw)

--- a/docs/api/diagram/autoplacement_property.md
+++ b/docs/api/diagram/autoplacement_property.md
@@ -1,5 +1,5 @@
 ---
-sidebar_label: autoplacement 
+sidebar_label: autoplacement
 title: autoplacement Property
 description: You can learn about the autoplacement property in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Diagram.
 ---
@@ -13,7 +13,7 @@ description: You can learn about the autoplacement property in the documentation
 :::info
 The `autoplacement` property works only in the default mode of the diagram and only for shapes. It does not work if you use groups or swimlanes.
 
-Autoplacement will be applied only after the [`autoPlace()`](api/diagram/autoplace_method.md) method is applied. 
+Autoplacement will be applied only after the [`autoPlace()`](api/diagram/autoplace_method.md) method is applied.
 :::
 
 ### Usage
@@ -45,8 +45,8 @@ autoplacement: {
     mode: "direct",
     graphPadding: 200,
     placeMode: "orthogonal",
-    itemPadding: 20, 
-    levelPadding: 20 
+    itemPadding: 20,
+    levelPadding: 20
 }
 ~~~
 
@@ -74,7 +74,7 @@ diagram.autoPlace();
 
 Connector lines with no arrows are aligned "from center to center". They are straight and diagonal.
 
-![](/img/direct_mode.png) 
+![](/img/direct_mode.png)
 
 ### "edges" mode
 
@@ -120,7 +120,7 @@ Shapes are arranged on imaginary circles relative to the central shape, i.e. the
 
 ![](/img/edges_radial.png)
 
-**Change log**: 
+**Change log**:
 
 - The `itemPadding` and `levelPadding` parameters are added in v6.1.3
 - The `placeMode` parameter is added in v5.0
@@ -130,7 +130,7 @@ Shapes are arranged on imaginary circles relative to the central shape, i.e. the
 - [Configuring autoplacement for shapes](guides/diagram/configuration.md#configuring-autoplacement-for-shapes)
 - [Arranging shapes automatically](guides/manipulating_items.md#arranging-shapes-automatically)
 
-**Related sample**: 
+**Related sample**:
 
 - [Diagram. Default mode. Radial autoplacement with padding options](https://snippet.dhtmlx.com/huut0l1s)
 - [Diagram. Default mode. Arranging a generated radial dataset with autoplacement](https://snippet.dhtmlx.com/rwsime82)

--- a/docs/api/diagram/beforecollapse_event.md
+++ b/docs/api/diagram/beforecollapse_event.md
@@ -14,7 +14,7 @@ description: You can learn about the beforeCollapse event in the documentation o
 
 ~~~jsx
 beforeCollapse: (
-    id: string | number, 
+    id: string | number,
     dir?: string
 ) => boolean | void;
 ~~~

--- a/docs/api/diagram/beforeexpand_event.md
+++ b/docs/api/diagram/beforeexpand_event.md
@@ -14,7 +14,7 @@ description: You can learn about the beforeExpand event in the documentation of 
 
 ~~~jsx
 beforeExpand: (
-    id: string | number, 
+    id: string | number,
     dir?: string
 ) => boolean | void;
 ~~~
@@ -23,7 +23,7 @@ beforeExpand: (
 
 The callback of the event takes the following parameters:
 
-- `id` - (required) the id of an item 
+- `id` - (required) the id of an item
 - `dir` - (optional) the side the children will be shown in relation to the parent shape (`"left"` or `"right"` for *type:`"topic"`*, otherwise - undefined)
 
 ### Returns

--- a/docs/api/diagram/beforesubmenuopen_event.md
+++ b/docs/api/diagram/beforesubmenuopen_event.md
@@ -14,8 +14,8 @@ description: You can learn about the beforeSubmenuOpen event in the documentatio
 
 ~~~jsx
 beforeSubmenuOpen: (
-    id: string | number, 
-    event: MouseEvent, 
+    id: string | number,
+    event: MouseEvent,
     subHeaderId?: string
 ) => boolean | void;
 ~~~

--- a/docs/api/diagram/collapseitem_method.md
+++ b/docs/api/diagram/collapseitem_method.md
@@ -14,7 +14,7 @@ description: You can learn about the collapseItem method in the documentation of
 
 ~~~jsx
 collapseItem(
-    id: string | number, 
+    id: string | number,
     dir?: string
 ): void;
 ~~~
@@ -22,7 +22,7 @@ collapseItem(
 ### Parameters
 
 - `id` - (required) the **ID** of the item
-- `dir` - (optional) defines the side, the children will be hidden in relation to the root shape: `"left"`, or `"right"`. 
+- `dir` - (optional) defines the side, the children will be hidden in relation to the root shape: `"left"`, or `"right"`.
   :::note
   The `dir` parameter can be used only when the diagram is initialized in the mindmap mode (*type:`"mindmap"`*)
   :::

--- a/docs/api/diagram/defaultlinktype_property.md
+++ b/docs/api/diagram/defaultlinktype_property.md
@@ -21,13 +21,13 @@ defaultLinkType?: "line" | "dash";
 ### Default config
 
 ~~~jsx
-defaultLinkType: "line" 
+defaultLinkType: "line"
 ~~~
 
 ### Example
 
 ~~~jsx
-const diagram = new dhx.Diagram("diagram_container", { 
+const diagram = new dhx.Diagram("diagram_container", {
     defaultLinkType: "dash"
 });
 ~~~

--- a/docs/api/diagram/defaults_property.md
+++ b/docs/api/diagram/defaults_property.md
@@ -22,8 +22,8 @@ defaults?: {
 
 The `defaults` property is an object which includes a set of `key:value` pairs where *key* is a type of a shape or line and *value* is an object with a set of configuration settings of the [shape](shapes/configuration_properties.md) or [line](lines/configuration_properties.md) correspondingly.
 
-:::note 
-There is no possibility to define `type` and `id` in the default configuration of a shape/line
+:::note
+You cannot define `type` and `id` in the default configuration of a shape/line
 :::
 
 ### Example

--- a/docs/api/diagram/defaultshapetype_property.md
+++ b/docs/api/diagram/defaultshapetype_property.md
@@ -47,7 +47,7 @@ defaultShapeType: "task"
 ### Example
 
 ~~~jsx
-const diagram = new dhx.Diagram("diagram_container", { 
+const diagram = new dhx.Diagram("diagram_container", {
     defaultShapeType: "img-card"
 });
 ~~~

--- a/docs/api/diagram/expanditem_method.md
+++ b/docs/api/diagram/expanditem_method.md
@@ -14,7 +14,7 @@ description: You can learn about the expandItem method in the documentation of t
 
 ~~~jsx
 expandItem(
-    id: string | number, 
+    id: string | number,
     dir?: string
 ): void;
 ~~~

--- a/docs/api/diagram/exportstyles_property.md
+++ b/docs/api/diagram/exportstyles_property.md
@@ -35,7 +35,7 @@ exportStyles: true
 Set the `exportStyles` property to *false* to prevent all styles from being sent to the export service:
 
 ~~~jsx
-const diagram = new dhx.Diagram("diagram_container", { 
+const diagram = new dhx.Diagram("diagram_container", {
     exportStyles: false
 });
 ~~~
@@ -43,7 +43,7 @@ const diagram = new dhx.Diagram("diagram_container", {
 Or define a set of styles you want to be exported. For that, you need to set string values with the absolute paths to the desired styles to the `exportStyles` array:
 
 ~~~jsx
-const diagram = new dhx.Diagram("diagram_container", { 
+const diagram = new dhx.Diagram("diagram_container", {
     exportStyles:[
         "https://mySite.com/exportStyle.css",
         "https://mySite.com/secondExportStyle.css"

--- a/docs/api/diagram/groupheaderclick_event.md
+++ b/docs/api/diagram/groupheaderclick_event.md
@@ -17,7 +17,7 @@ If a click is done over a header of a swimlane, the event will be fired on the s
 ~~~jsx
 groupHeaderClick: (
     id: string | number,
-    event: MouseEvent, 
+    event: MouseEvent,
     subHeaderId?: string
 ) => void;
 ~~~

--- a/docs/api/diagram/groupheaderdblclick_event.md
+++ b/docs/api/diagram/groupheaderdblclick_event.md
@@ -16,8 +16,8 @@ If a double-click is done over a header of a swimlane, the event will be fired o
 
 ~~~jsx
 groupHeaderDblClick: (
-    id: string | number, 
-    event: MouseEvent, 
+    id: string | number,
+    event: MouseEvent,
     subHeaderId?: string
 ) => void;
 ~~~

--- a/docs/api/diagram/groupmousedown_event.md
+++ b/docs/api/diagram/groupmousedown_event.md
@@ -16,7 +16,7 @@ If a pointing device button is pressed while the pointer is over a swimlane, the
 
 ~~~jsx
 groupMouseDown: (
-    id: string | number, 
+    id: string | number,
     event: MouseEvent
 ) => void;
 ~~~

--- a/docs/api/diagram/itemclick_event.md
+++ b/docs/api/diagram/itemclick_event.md
@@ -16,7 +16,7 @@ If a click is done over a swimlane, the event will be fired on the cell of the s
 
 ~~~jsx
 itemClick: (
-    id: string | number, 
+    id: string | number,
     event: MouseEvent
 ) => void;
 ~~~

--- a/docs/api/diagram/itemdblclick_event.md
+++ b/docs/api/diagram/itemdblclick_event.md
@@ -16,7 +16,7 @@ If a double-click is done over a swimlane, the event will be fired on the cell o
 
 ~~~jsx
 itemDblClick: (
-    id: string | number, 
+    id: string | number,
     event: MouseEvent
 ) => void;
 ~~~

--- a/docs/api/diagram/itemmousedown_event.md
+++ b/docs/api/diagram/itemmousedown_event.md
@@ -16,7 +16,7 @@ If a pointing device button is pressed while the pointer is over a swimlane, the
 
 ~~~jsx
 itemMouseDown: (
-    id: string | number, 
+    id: string | number,
     event: MouseEvent
 ) => void;
 ~~~

--- a/docs/api/diagram/itemmouseout_event.md
+++ b/docs/api/diagram/itemmouseout_event.md
@@ -14,7 +14,7 @@ description: You can learn about the itemMouseOut event in the documentation of 
 
 ~~~jsx
 itemMouseOut: (
-    id: string | number, 
+    id: string | number,
     event: MouseEvent
 ) => void;
 ~~~

--- a/docs/api/diagram/itemmouseover_event.md
+++ b/docs/api/diagram/itemmouseover_event.md
@@ -14,7 +14,7 @@ description: You can learn about the itemMouseOver event in the documentation of
 
 ~~~jsx
 itemMouseOver: (
-    id: string | number, 
+    id: string | number,
     event: MouseEvent
 ) => void;
 ~~~

--- a/docs/api/diagram/lineclick_event.md
+++ b/docs/api/diagram/lineclick_event.md
@@ -14,7 +14,7 @@ description: You can learn about the lineClick event in the documentation of the
 
 ~~~jsx
 lineClick: (
-    id: string | number, 
+    id: string | number,
     event: MouseEvent
 ) => void;
 ~~~

--- a/docs/api/diagram/linedblclick_event.md
+++ b/docs/api/diagram/linedblclick_event.md
@@ -14,7 +14,7 @@ description: You can learn about the lineDblClick event in the documentation of 
 
 ~~~jsx
 lineDblClick: (
-    id: string | number, 
+    id: string | number,
     event: MouseEvent
 ) => void;
 ~~~

--- a/docs/api/diagram/linemousedown_event.md
+++ b/docs/api/diagram/linemousedown_event.md
@@ -14,7 +14,7 @@ description: You can learn about the lineMouseDown event in the documentation of
 
 ~~~jsx
 lineMouseDown: (
-    id: string | number, 
+    id: string | number,
     event: MouseEvent
 ) => void;
 ~~~

--- a/docs/api/diagram/linetitleclick_event.md
+++ b/docs/api/diagram/linetitleclick_event.md
@@ -14,8 +14,8 @@ description: You can learn about the lineTitleClick event in the documentation o
 
 ~~~jsx
 lineTitleClick: (
-    lineId: string | number, 
-    titleId: string | number, 
+    lineId: string | number,
+    titleId: string | number,
     event: MouseEvent
 ) => void;
 ~~~

--- a/docs/api/diagram/linetitledblclick_event.md
+++ b/docs/api/diagram/linetitledblclick_event.md
@@ -14,8 +14,8 @@ description: You can learn about the lineTitleDblClick event in the documentatio
 
 ~~~jsx
 lineTitleDblClick: (
-    lineId: string | number, 
-    titleId: string | number, 
+    lineId: string | number,
+    titleId: string | number,
     event: MouseEvent
 ) => void;
 ~~~

--- a/docs/api/diagram/linetitlemousedown_event.md
+++ b/docs/api/diagram/linetitlemousedown_event.md
@@ -13,9 +13,9 @@ description: You can learn about the lineTitleMouseDown event in the documentati
 ### Usage
 
 ~~~jsx
-lineTitleMouseDown: ( 
-    lineId: string | number, 
-    titleId: string | number, 
+lineTitleMouseDown: (
+    lineId: string | number,
+    titleId: string | number,
     event: MouseEvent
 ) => void;
 ~~~

--- a/docs/api/diagram/margin_property.md
+++ b/docs/api/diagram/margin_property.md
@@ -43,7 +43,7 @@ margin: {
 
 ~~~jsx
 const diagram = new dhx.Diagram("diagram_container", {
-    type: "org", 
+    type: "org",
     margin: {
         x: 20, y: 20,
         itemX: 50, itemY: 50

--- a/docs/api/diagram/scale_property.md
+++ b/docs/api/diagram/scale_property.md
@@ -25,7 +25,7 @@ scale: 1
 ### Example
 
 ~~~jsx
-const diagram = new dhx.Diagram("diagram_container", { 
+const diagram = new dhx.Diagram("diagram_container", {
     scale: 0.7
 });
 ~~~

--- a/docs/api/diagram/scroll_event.md
+++ b/docs/api/diagram/scroll_event.md
@@ -26,9 +26,9 @@ The callback of the event takes the following parameter:
 
 ~~~jsx {10-12}
 // initializing Diagram
-const diagram = new dhx.Diagram("diagram_container", { 
-    type: "org", 
-    scroll: true         
+const diagram = new dhx.Diagram("diagram_container", {
+    type: "org",
+    scroll: true
 });
 // loading data
 diagram.data.parse(data);

--- a/docs/api/diagram/select_property.md
+++ b/docs/api/diagram/select_property.md
@@ -25,12 +25,12 @@ select: false
 ### Example
 
 ~~~jsx
-const diagram = new dhx.Diagram("diagram_container", { 
+const diagram = new dhx.Diagram("diagram_container", {
     select: true
 });
 ~~~
 
 **Related articles**:
 
-- [Enabling items selection](guides/diagram/configuration.md#enabling-items-selection) 
+- [Enabling items selection](guides/diagram/configuration.md#enabling-items-selection)
 - [Selecting items](guides/manipulating_items.md#selecting-items)

--- a/docs/api/diagram/shapeclick_event.md
+++ b/docs/api/diagram/shapeclick_event.md
@@ -14,7 +14,7 @@ description: You can learn about the shapeClick event in the documentation of th
 
 ~~~jsx
 shapeClick: (
-    id: string | number, 
+    id: string | number,
     event: MouseEvent
 ) => void;
 ~~~

--- a/docs/api/diagram/shapedblclick_event.md
+++ b/docs/api/diagram/shapedblclick_event.md
@@ -14,7 +14,7 @@ description: You can learn about the shapeDblClick event in the documentation of
 
 ~~~jsx
 shapeDblClick: (
-    id: string | number, 
+    id: string | number,
     event: MouseEvent
 ) => void;
 ~~~

--- a/docs/api/diagram/shapeiconclick_event.md
+++ b/docs/api/diagram/shapeiconclick_event.md
@@ -14,7 +14,7 @@ description: You can learn about the shapeIconClick event in the documentation o
 
 ~~~jsx
 "shapeIconClick": (
-    id: string | number, 
+    id: string | number,
     event: MouseEvent
 ) => void;
 ~~~

--- a/docs/api/diagram/shapemousedown_event.md
+++ b/docs/api/diagram/shapemousedown_event.md
@@ -14,7 +14,7 @@ description: You can learn about the shapeMouseDown event in the documentation o
 
 ~~~jsx
 shapeMouseDown: (
-    id: string | number, 
+    id: string | number,
     event: MouseEvent
 ) => void;
 ~~~

--- a/docs/api/diagram/showitem_method.md
+++ b/docs/api/diagram/showitem_method.md
@@ -8,7 +8,7 @@ description: You can learn about the showItem method in the documentation of the
 
 ### Description
 
-@short: Adjusts scroll to make the target item visible 
+@short: Adjusts scroll to make the target item visible
 
 ### Usage
 

--- a/docs/api/diagram/toolbar_property.md
+++ b/docs/api/diagram/toolbar_property.md
@@ -1,5 +1,5 @@
 ---
-sidebar_label: toolbar 
+sidebar_label: toolbar
 title: toolbar Property
 description: You can learn about the toolbar property in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Diagram.
 ---
@@ -38,7 +38,7 @@ The `toolbar` array includes a set of icon objects. Each icon object can have th
 ### Example
 
 ~~~jsx
-const diagram = new dhx.Diagram("diagram_container", { 
+const diagram = new dhx.Diagram("diagram_container", {
     type: "org",
     select: true,
     // setting a toolbar with buttons for items

--- a/docs/api/diagram/type_property.md
+++ b/docs/api/diagram/type_property.md
@@ -44,7 +44,7 @@ DHTMLX Diagram can be initialized in one of the following modes: `"default"`, `"
 
 <iframe src="https://snippet.dhtmlx.com/4h5fi7xd?mode=result" frameborder="0" class="snippet_iframe" width="100%" height="600"></iframe>
 
-**Change log**: 
+**Change log**:
 
 - The `"pert"` type was added in v6.1
 

--- a/docs/api/diagram/typeconfig_property.md
+++ b/docs/api/diagram/typeconfig_property.md
@@ -6,7 +6,7 @@ description: You can learn about the typeConfig property in the documentation of
 
 # typeConfig
 
-:::info 
+:::info
 The property does not work in the Editor
 :::
 
@@ -41,7 +41,7 @@ typeConfig?: {
 ~~~jsx
 typeConfig?: {
     dateFormat?: string; // %d-%m-%Y by default
-} 
+}
 ~~~
 
 ### Parameters
@@ -54,7 +54,7 @@ The `typeConfig` object can include one of the following parameters:
       - `"right"` - puts child shapes of the graph to the right of the root shape
     - `side` - (optional) an object which sets the mandatory direction for the specified child shapes. The object contains a set of *key:value* pairs where *key* is the direction of the shapes (left, right) and *value* is an array with the ids of the shapes
 - for the PERT mode:
-    - `dateFormat` - (optional) sets the format of rendering dates in the shapes of the `task` type. Affects rendering of dates in the user interface 
+    - `dateFormat` - (optional) sets the format of rendering dates in the shapes of the `task` type. Affects rendering of dates in the user interface
 
 :::tip
 You can use either the `direction` attribute or the `side` one for the diagram in the mindmap mode. Don't use both of them at the same time!
@@ -65,7 +65,7 @@ You can use either the `direction` attribute or the `side` one for the diagram i
 - for the mindmap mode:
 
 ~~~jsx {3-5}
-const diagram = new dhx.Diagram("diagram_container", { 
+const diagram = new dhx.Diagram("diagram_container", {
     type: "mindmap",
     typeConfig: {
         direction: "right"
@@ -76,7 +76,7 @@ const diagram = new dhx.Diagram("diagram_container", {
 or
 
 ~~~jsx {3-8}
-const diagram = new dhx.Diagram("diagram_container", { 
+const diagram = new dhx.Diagram("diagram_container", {
     type: "mindmap",
     typeConfig: {
         side: {
@@ -100,7 +100,7 @@ const diagram = new dhx.Diagram("diagram_container", {
 });
 ~~~
 
-**Change log**: 
+**Change log**:
 
 - The `dateFormat` property for the PERT mode was added in v6.1
 - Added in v3.1.

--- a/docs/api/diagram_editor/copymanager/api_overview.md
+++ b/docs/api/diagram_editor/copymanager/api_overview.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Copy manager API overview
-title: Copy manager API overview 
+title: Copy manager API overview
 description: You can check a Copy manager overview in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Diagram.
 ---
 
@@ -9,7 +9,7 @@ description: You can check a Copy manager overview in the documentation of the D
 A set of APIs that you can use when copying and pasting items of the Diagram Editor. Use the `model` keyword to access the Copy manager via the `editor` object:
 
 ~~~jsx {5}
-const editor = new dhx.DiagramEditor("editor_container", { 
+const editor = new dhx.DiagramEditor("editor_container", {
     type: "default" // only default
 });
 // ...

--- a/docs/api/diagram_editor/copymanager/methods/copy_method.md
+++ b/docs/api/diagram_editor/copymanager/methods/copy_method.md
@@ -26,24 +26,24 @@ copy(ids?: (string | number)[]): void;
 
 ### Example
 
-- call the method without arguments to copy elements from the selection list 
+- call the method without arguments to copy elements from the selection list
 
 ~~~jsx {5}
-const editor = new dhx.DiagramEditor("editor_container", { 
+const editor = new dhx.DiagramEditor("editor_container", {
     type: "default", // only default
 });
 // ...
 editor.model.copy(); // copies selected items
 ~~~
 
-- pass some ids to the method to copy the corresponding elements 
+- pass some ids to the method to copy the corresponding elements
 
 ~~~jsx {5}
-const editor = new dhx.DiagramEditor("editor_container", { 
+const editor = new dhx.DiagramEditor("editor_container", {
     type: "default", // only default
 });
 // ...
-editor.model.copy(["1", "2"]); // copies the specified items 
+editor.model.copy(["1", "2"]); // copies the specified items
 ~~~
 
 **Change log**: Added in v6.0

--- a/docs/api/diagram_editor/copymanager/methods/copystyles_method.md
+++ b/docs/api/diagram_editor/copymanager/methods/copystyles_method.md
@@ -25,7 +25,7 @@ copyStyles(id?: string | number): void;
 -  call the method without arguments to copy styles of the *first element from the selection list*
 
 ~~~jsx {5}
-const editor = new dhx.DiagramEditor("editor_container", { 
+const editor = new dhx.DiagramEditor("editor_container", {
     type: "default",
 });
 // ...
@@ -35,7 +35,7 @@ editor.model.copyStyles(); // copies styles of the first element from the select
 - pass the id of some element to the method to copy its styles
 
 ~~~jsx {5}
-const editor = new dhx.DiagramEditor("editor_container", { 
+const editor = new dhx.DiagramEditor("editor_container", {
     type: "default",
 });
 // ...

--- a/docs/api/diagram_editor/copymanager/methods/paste_method.md
+++ b/docs/api/diagram_editor/copymanager/methods/paste_method.md
@@ -23,7 +23,7 @@ paste(): void;
 ### Example
 
 ~~~jsx {5-6}
-const editor = new dhx.DiagramEditor("editor_container", { 
+const editor = new dhx.DiagramEditor("editor_container", {
     type: "default" // only default
 });
 // ...

--- a/docs/api/diagram_editor/copymanager/methods/pastestyles_method.md
+++ b/docs/api/diagram_editor/copymanager/methods/pastestyles_method.md
@@ -25,7 +25,7 @@ pasteStyles(ids?: (string | number)[]): void;
 - call the method without arguments to apply styles to the elements from the selection list
 
 ~~~jsx {5-6}
-const editor = new dhx.DiagramEditor("editor_container", { 
+const editor = new dhx.DiagramEditor("editor_container", {
     type: "default"
 });
 // ...
@@ -36,8 +36,8 @@ editor.model.pasteStyles(); // applies copied styles to the elements from the se
 - pass the ids of certain elements to the method to apply the copied styles to them
 
 ~~~jsx {5-6}
-const editor = new dhx.DiagramEditor("editor_container", { 
-    type: "default" 
+const editor = new dhx.DiagramEditor("editor_container", {
+    type: "default"
 });
 // ...
 editor.model.copyStyles("2"); // copies styles of the specified element

--- a/docs/api/diagram_editor/editbar/api_overview.md
+++ b/docs/api/diagram_editor/editbar/api_overview.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Editbar API overview
-title: Editbar API overview 
-description: You can check a Editbar overview in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Diagram.
+title: Editbar API overview
+description: You can check an Editbar overview in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Diagram.
 ---
 
 # Editbar API overview

--- a/docs/api/diagram_editor/editbar/basic_controls/avatar.md
+++ b/docs/api/diagram_editor/editbar/basic_controls/avatar.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Avatar
-title: Editbar Basic Controls - Avatar 
+title: Editbar Basic Controls - Avatar
 description: You can explore the Avatar control of Editbar in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Suite.
 ---
 
@@ -23,7 +23,7 @@ description: You can explore the Avatar control of Editbar in the documentation 
     disabled?: boolean, // false by default
     readOnly?: boolean, // false by default
 
-    removeIcon?: boolean, // true by default 
+    removeIcon?: boolean, // true by default
     circle?: boolean, // false by default
     icon?: string,
     placeholder?: string,
@@ -48,7 +48,7 @@ description: You can explore the Avatar control of Editbar in the documentation 
     headerParams?: { [key: string]: any },
     updateFromResponse?: boolean,  // true by default
 
-    // service properties and methods 
+    // service properties and methods
     $on?: { [eventName: string]: function },
     $handler?: function,
     $setValue?: function,
@@ -64,15 +64,15 @@ description: You can explore the Avatar control of Editbar in the documentation 
 - `wrap` - (optional) allows displaying the external wrapping. *false* by default
 - `target` - (optional) sets an URL to the server-side script that will process file upload, the property is required when an image is sent to the server via the control
 :::note
-While loading an image and sending it to the server via the `target` property, note that the [*value* object](https://docs.dhtmlx.com/suite/form/api/avatar/api_avatar_properties/#description) will be sent to the server. The file itself will be recorded in the dataset in the *base64* format. You can redefine this logic using the [service methods](#service-properties-and-methods). 
+While loading an image and sending it to the server via the `target` property, note that the [*value* object](https://docs.dhtmlx.com/suite/form/api/avatar/api_avatar_properties/#description) will be sent to the server. The file itself will be recorded in the dataset in the *base64* format. You can redefine this logic using the [service methods](#service-properties-and-methods).
 :::
 - `hidden` - (optional) defines whether a control is hidden. *false* by default
 - `disabled` - (optional) defines whether a control is enabled (*false*) or disabled (*true*). *false* by default
 - `readOnly` - (optional) sets the readonly mode for the control. *false* by default
-- `removeIcon` - (optional) enables the possibility to clear the control by means of the UI. *true* by default
+- `removeIcon` - (optional) enables clearing the control via the UI. *true* by default
 - `circle` - (optional) sets the mode of displaying the control with rounded corners. *false* by default
 - `icon` - (optional) allows setting the CSS class of an icon when there is no image uploaded, doesn't work together with the `preview` property
-- `placeholder` - (optional) allows setting a text to be visible when there is no image uploaded, doesn't work together with the `preview` property
+- `placeholder` - (optional) allows setting text to be visible when there is no image uploaded, doesn't work together with the `preview` property
 - `preview` - (optional) specifies the absolute path to the preview image. The preview image is visible, when an image is not uploaded
 - `alt` - (optional) sets the attribute of the &lt;img&gt; tag - an alternative text when there is no image uploaded
 - `size` - (optional) allows setting one of the three basic control's sizes: `"small"` | `"medium"` | `"large"` , or applying a custom size in px. `"medium"` by default
@@ -93,7 +93,7 @@ While loading an image and sending it to the server via the `target` property, n
 ### Service properties and methods
 
 :::warning
-Note that it's highly not recommended to redefine the service properties and methods for the default types of controls, since it may cause breaks in their functionality. 
+Note that we strongly recommend not redefining the service properties and methods for the default types of controls, since it may cause breaks in their functionality.
 :::
 
 - `$on` - (optional) - allows setting an event listener. The object has the following properties:
@@ -101,12 +101,12 @@ Note that it's highly not recommended to redefine the service properties and met
         - `object` - an object with the following properties:
             - `control` - the [Avatar](https://docs.dhtmlx.com/suite/form/avatar/) Form control
             - `editor` - the object of the Diagram Editor
-            - `id` - the id of a Diagram item 
+            - `id` - the id of a Diagram item
         - `arguments` - (optional) - the [original event arguments](https://docs.dhtmlx.com/suite/category/form-avatar-events/)
 - `$handler` - (optional) - a callback function that allows handling actions on firing the `change` event of the [Avatar](https://docs.dhtmlx.com/suite/form/avatar/) Form control and the `change` event of DataCollection. Called with the following parameter:
     - `object` - an object with the following properties:
-        - `id` - the id of a Diagram item 
-        - `key` - the name of the specified/modified property in the object of a Diagram item 
+        - `id` - the id of a Diagram item
+        - `key` - the name of the specified/modified property in the object of a Diagram item
         - `editor` - the object of the Diagram Editor
         - `control` - the object of the [Avatar](https://docs.dhtmlx.com/suite/form/avatar/) Form control the component is built on
         - `value` - the new value of the [Avatar](https://docs.dhtmlx.com/suite/form/avatar/) Form control
@@ -114,7 +114,7 @@ Note that it's highly not recommended to redefine the service properties and met
     - `object` - an object with the following properties:
         - `editor` - the object of the Diagram Editor
         - `control` - the object of the [Avatar](https://docs.dhtmlx.com/suite/form/avatar/) Form control the component is built on
-        - `value` - the value of a Diagram item 
+        - `value` - the value of a Diagram item
 - `$layout` - (optional) - a callback function that allows setting the structure of a control. Returns the configuration of the [Avatar](https://docs.dhtmlx.com/suite/form/avatar/) Form control. Called with the following parameter:
     - `object` - the configuration of the control without service properties
 

--- a/docs/api/diagram_editor/editbar/basic_controls/button.md
+++ b/docs/api/diagram_editor/editbar/basic_controls/button.md
@@ -1,10 +1,10 @@
 ---
 sidebar_label: Button
-title: Editbar Basic Controls - Button 
+title: Editbar Basic Controls - Button
 description: You can explore the Button control of Editbar in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Suite.
 ---
 
-# Button 
+# Button
 
 @short: The basic button control that can have an icon.
 
@@ -16,7 +16,7 @@ description: You can explore the Button control of Editbar in the documentation 
 {
     type: "button",
     text?: string,
-    
+
     css?: string,
     disabled?: boolean, // false by default
     hidden?: boolean, // false by default
@@ -32,7 +32,7 @@ description: You can explore the Button control of Editbar in the documentation 
     size?: "small" | "medium", // "medium" by default
     view?: "flat" | "link", // "flat" by default
 
-    // service properties and methods 
+    // service properties and methods
     $on?: { [eventName: string]: function },
     $layout?: function
 }
@@ -60,7 +60,7 @@ description: You can explore the Button control of Editbar in the documentation 
 ### Service properties and methods
 
 :::warning
-Note that it's highly not recommended to redefine the service properties and methods for the default types of controls, since it may cause breaks in their functionality. 
+Note that we strongly recommend not redefining the service properties and methods for the default types of controls, since it may cause breaks in their functionality.
 :::
 
 - `$on` - (optional) - allows setting an event listener. The object has the following properties:
@@ -68,7 +68,7 @@ Note that it's highly not recommended to redefine the service properties and met
         - `object` - an object with the following properties:
             - `control` - the [Button](https://docs.dhtmlx.com/suite/form/button/) Form control
             - `editor` - the object of the Diagram Editor
-            - `id` - the id of a Diagram item 
+            - `id` - the id of a Diagram item
         - `arguments` - (optional) - the [original event arguments](https://docs.dhtmlx.com/suite/category/form-button-events/)
 - `$layout` - (optional) - a callback function that allows setting the structure of a control. Returns the configuration of the [Button](https://docs.dhtmlx.com/suite/form/button/) Form control. Called with the following parameter:
     - `object` - the configuration of a control without service properties

--- a/docs/api/diagram_editor/editbar/basic_controls/checkbox.md
+++ b/docs/api/diagram_editor/editbar/basic_controls/checkbox.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Checkbox
-title: Editbar Basic Controls - Checkbox 
+title: Editbar Basic Controls - Checkbox
 description: You can explore the Checkbox control of Editbar in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Suite.
 ---
 
@@ -30,7 +30,7 @@ description: You can explore the Checkbox control of Editbar in the documentatio
     labelWidth?: string | number,
     labelPosition?: "left" | "top", // "top" by default
 
-    // service properties and methods 
+    // service properties and methods
     $on?: { [eventName: string]: function },
     $handler?: function,
     $setValue?: function,
@@ -61,7 +61,7 @@ The control can be used both with the *boolean* value and the *string* one, if t
 ### Service properties and methods
 
 :::warning
-Note that it's highly not recommended to redefine the service properties and methods for the default types of controls, since it may cause breaks in their functionality. 
+Note that we strongly recommend not redefining the service properties and methods for the default types of controls, since it may cause breaks in their functionality.
 :::
 
 - `$on` - (optional) - allows setting an event listener. The object has the following properties:
@@ -69,12 +69,12 @@ Note that it's highly not recommended to redefine the service properties and met
         - `object` - an object with the following properties:
             - `control` - the [Checkbox](https://docs.dhtmlx.com/suite/form/checkbox/) Form control
             - `editor` - the object of the Diagram Editor
-            - `id` - the id of a Diagram item 
+            - `id` - the id of a Diagram item
         - `arguments` - (optional) - the [original event arguments](https://docs.dhtmlx.com/suite/category/form-checkbox-events/)
 - `$handler` - (optional) - a callback function that allows handling actions on firing the `change` event of the [Checkbox](https://docs.dhtmlx.com/suite/form/checkbox/) Form control and the `change` event of DataCollection. Called with the following parameter:
     - `object` - an object with the following properties:
-        - `id` - the id of a Diagram item 
-        - `key` - the name of the specified/modified property or the path to it in the object of a Diagram item 
+        - `id` - the id of a Diagram item
+        - `key` - the name of the specified/modified property or the path to it in the object of a Diagram item
         - `editor` - the object of the Diagram Editor
         - `control` - the object of the [Checkbox](https://docs.dhtmlx.com/suite/form/checkbox/) Form control the component is built on
         - `value` - the new value of the [Checkbox](https://docs.dhtmlx.com/suite/form/checkbox/) Form control
@@ -82,7 +82,7 @@ Note that it's highly not recommended to redefine the service properties and met
     - `object` - an object with the following properties:
         - `editor` - the object of the Diagram Editor
         - `control` - the object of the [Checkbox](https://docs.dhtmlx.com/suite/form/checkbox/) Form control the component is built on
-        - `value` - the value of a Diagram item 
+        - `value` - the value of a Diagram item
 - `$layout` - (optional) - a callback function that allows setting the structure of a control. Returns the configuration of the [Checkbox](https://docs.dhtmlx.com/suite/form/checkbox/) Form control. Called with the following parameter:
     - `object` - the configuration of a control without service properties
 

--- a/docs/api/diagram_editor/editbar/basic_controls/checkboxgroup.md
+++ b/docs/api/diagram_editor/editbar/basic_controls/checkboxgroup.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: CheckboxGroup
-title: Editbar Basic Controls - CheckboxGroup 
+title: Editbar Basic Controls - CheckboxGroup
 description: You can explore the CheckboxGroup control of Editbar in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Suite.
 ---
 
@@ -25,20 +25,20 @@ description: You can explore the CheckboxGroup control of Editbar in the documen
     },
     key?: string | string[],
     wrap?: boolean, // false by default
-    
+
     css?: string,
     disabled?: boolean, // false by default
     hidden?: boolean, // false by default
     height?: string | number | "content", // "content" by default
     width?: string | number | "content", // "content" by default
     padding?: string | number,
-    
+
     // for `wrap:true` check the label properties for the Fieldset
     label?: string,
     labelWidth?: string | number,
     labelPosition?: "left" | "top", // "top" by default
 
-    // service properties and methods 
+    // service properties and methods
     $on?: { [eventName: string]: function },
     $handler?: function,
     $setValue?: function,
@@ -72,7 +72,7 @@ The objects with the `checkbox` configuration inside the control can be used bot
 #### Basic properties
 
 - `type` - (required) the type of a control. Set it to `"checkboxGroup"`
-- `key` - (optional) the name of the specified/modified property or the path to it in the object of a Diagram item 
+- `key` - (optional) the name of the specified/modified property or the path to it in the object of a Diagram item
 - `wrap` - (optional) allows displaying the external wrapping. *false* by default
 - `options` - (required) an object with options of a CheckboxGroup. The object can contain the following attributes:
     - `rows` - (optional) arranges [checkboxes](#checkbox-properties) inside the CheckboxGroup control vertically
@@ -94,7 +94,7 @@ The objects with the `checkbox` configuration inside the control can be used bot
 #### Service properties and methods
 
 :::warning
-Note that it's highly not recommended to redefine the service properties and methods for the default types of controls, since it may cause breaks in their functionality. 
+Note that we strongly recommend not redefining the service properties and methods for the default types of controls, since it may cause breaks in their functionality.
 :::
 
 - `$on` - (optional) - allows setting an event listener. The object has the following properties:
@@ -102,12 +102,12 @@ Note that it's highly not recommended to redefine the service properties and met
         - `object` - an object with the following properties:
             - `control` - the [CheckboxGroup](https://docs.dhtmlx.com/suite/form/checkboxgroup/) Form control
             - `editor` - the object of the Diagram Editor
-            - `id` - the id of a Diagram item 
+            - `id` - the id of a Diagram item
         - `arguments` - (optional) - the [original event arguments](https://docs.dhtmlx.com/suite/category/form-checkboxgroup-events/)
 - `$handler` - (optional) - a callback function that allows handling actions on firing the `change` event of the [CheckboxGroup](https://docs.dhtmlx.com/suite/form/checkboxgroup/) Form control and the `change` event of DataCollection. Called with the following parameter:
     - `object` - an object with the following properties:
-        - `id` - the id of a Diagram item 
-        - `key` - the name of the specified/modified property or the path to it in the object of a Diagram item 
+        - `id` - the id of a Diagram item
+        - `key` - the name of the specified/modified property or the path to it in the object of a Diagram item
         - `editor` - the object of the Diagram Editor
         - `control` - the object of the [CheckboxGroup](https://docs.dhtmlx.com/suite/form/checkboxgroup/) Form control the component is built on
         - `value` - the new value of the [CheckboxGroup](https://docs.dhtmlx.com/suite/form/checkboxgroup/) Form control
@@ -115,11 +115,11 @@ Note that it's highly not recommended to redefine the service properties and met
     - `object` - an object with the following properties:
         - `editor` - the object of the Diagram Editor
         - `control` - the object of the [CheckboxGroup](https://docs.dhtmlx.com/suite/form/checkboxgroup/) Form control the component is built on
-        - `value` - the value of a Diagram item 
+        - `value` - the value of a Diagram item
 - `$layout` - (optional) - a callback function that allows setting the structure of a control. Returns the configuration of the [CheckboxGroup](https://docs.dhtmlx.com/suite/form/checkboxgroup/) Form control. Called with the following parameter:
     - `object` - the configuration of a control without service properties
 
-### Checkbox properties 
+### Checkbox properties
 
 - `id` - (optional) the id of a control, auto-generated if not set
 - `text` - (optional) the text label of a checkbox
@@ -159,14 +159,14 @@ const editor = new dhx.DiagramEditor("editor_container", {
     }
 });
 editor.parse([
-    { 
-        "type": "rectangle", 
-        "products": { 
-            "diagram": "diagram", 
-            "suite": "", 
-            "gantt": true, 
-            "spreadsheet": false 
-        } 
+    {
+        "type": "rectangle",
+        "products": {
+            "diagram": "diagram",
+            "suite": "",
+            "gantt": true,
+            "spreadsheet": false
+        }
     }
 ]);
 ~~~

--- a/docs/api/diagram_editor/editbar/basic_controls/colorpicker.md
+++ b/docs/api/diagram_editor/editbar/basic_controls/colorpicker.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Colorpicker
-title: Editbar Basic Controls - Colorpicker 
+title: Editbar Basic Controls - Colorpicker
 description: You can explore the Colorpicker control of Editbar in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Suite.
 ---
 
@@ -17,14 +17,14 @@ description: You can explore the Colorpicker control of Editbar in the documenta
     type: "colorpicker",
     key?: string | string[],
     wrap?: boolean, // false by default
-    
+
     css?: string,
     disabled?: boolean, // false by default
     hidden?: boolean, // false by default
     height?: string | number | "content", // "content" by default
     width?: string | number | "content", // "content" by default
     padding?: string | number,
-    
+
     customColors?: string[],
     grayShades?: boolean, // true by default
     icon?: string,
@@ -39,7 +39,7 @@ description: You can explore the Colorpicker control of Editbar in the documenta
     labelWidth?: string | number,
     labelPosition?: "left" | "top", // "top" by default
 
-    // service properties and methods 
+    // service properties and methods
     $on?: { [eventName: string]: function },
     $handler?: function,
     $setValue?: function,
@@ -52,7 +52,7 @@ description: You can explore the Colorpicker control of Editbar in the documenta
 ### Basic properties
 
 - `type` - (required) the type of a control. Set it to `"colorpicker"`
-- `key` - (optional) the name of the specified/modified property or the path to it in the object of a Diagram item 
+- `key` - (optional) the name of the specified/modified property or the path to it in the object of a Diagram item
 - `wrap` - (optional) allows displaying the external wrapping. *false* by default
 - `css` - (optional) adds style classes to a control
 - `disabled` - (optional) defines whether a control is enabled (*false*) or disabled (*true*). *false* by default
@@ -75,7 +75,7 @@ description: You can explore the Colorpicker control of Editbar in the documenta
 ### Service properties and methods
 
 :::warning
-Note that it's highly not recommended to redefine the service properties and methods for the default types of controls, since it may cause breaks in their functionality. 
+Note that we strongly recommend not redefining the service properties and methods for the default types of controls, since it may cause breaks in their functionality.
 :::
 
 - `$on` - (optional) - allows setting an event listener. The object has the following properties:
@@ -87,8 +87,8 @@ Note that it's highly not recommended to redefine the service properties and met
         - `arguments` - (optional) - the [original event arguments](https://docs.dhtmlx.com/suite/category/form-colorpicker-events/)
 - `$handler` - (optional) - a callback function that allows handling actions on firing the `change` and `input` events of the [Colorpicker](https://docs.dhtmlx.com/suite/form/colorpicker/) Form control and the `change` event of DataCollection. Called with the following parameter:
     - `object` - an object with the following properties:
-        - `id` - the id of a Diagram item 
-        - `key` - the name of the specified/modified property or the path to it in the object of a Diagram item 
+        - `id` - the id of a Diagram item
+        - `key` - the name of the specified/modified property or the path to it in the object of a Diagram item
         - `editor` - the object of the Diagram Editor
         - `control` - the object of the [Colorpicker](https://docs.dhtmlx.com/suite/form/colorpicker/) Form control the component is built on
         - `value` - the new value of the [Colorpicker](https://docs.dhtmlx.com/suite/form/colorpicker/) Form control
@@ -96,7 +96,7 @@ Note that it's highly not recommended to redefine the service properties and met
     - `object` - an object with the following properties:
         - `editor` - the object of the Diagram Editor
         - `control` - the object of the [Colorpicker](https://docs.dhtmlx.com/suite/form/colorpicker/) Form control the component is built on
-        - `value` - the value of a Diagram item 
+        - `value` - the value of a Diagram item
 - `$layout` - (optional) - a callback function that allows setting the structure of a control. Returns the configuration of the [Colorpicker](https://docs.dhtmlx.com/suite/form/colorpicker/) Form control. Called with the following parameter:
     - `object` - the configuration of a control without service properties
 

--- a/docs/api/diagram_editor/editbar/basic_controls/combo.md
+++ b/docs/api/diagram_editor/editbar/basic_controls/combo.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Combo
-title: Editbar Basic Controls - Combo 
+title: Editbar Basic Controls - Combo
 description: You can explore the Combo control of Editbar in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Suite.
 ---
 
@@ -18,7 +18,7 @@ description: You can explore the Combo control of Editbar in the documentation o
     options: (object | string)[],
     key?: string | string[],
     wrap?: boolean, // false by default
-    
+
     css?: string,
     disabled?: boolean, // false by default
     hidden?: boolean, // false by default
@@ -29,7 +29,7 @@ description: You can explore the Combo control of Editbar in the documentation o
     filter?: (item: any, input: string) => boolean,
     eventHandlers?: {
         [eventName: string]: {
-            [className: string]: (event: Event, id: string | number) => void | boolean; 
+            [className: string]: (event: Event, id: string | number) => void | boolean;
         };
     },
     itemHeight?: number | string, // 32 by default
@@ -41,13 +41,13 @@ description: You can explore the Combo control of Editbar in the documentation o
     selectAllButton?: boolean, // false by default
     template?: (item: object) => string,
     virtual?: boolean, // false by default
-    
+
     // for `wrap:true` check the label properties for the Fieldset
     label?: string,
     labelWidth?: string | number,
     labelPosition?: "left" | "top", // "top" by default
 
-    // service properties and methods 
+    // service properties and methods
     $on?: { [eventName: string]: function },
     $handler?: function,
     $setValue?: function,
@@ -71,8 +71,8 @@ Option configuration object inside Combo:
 #### Basic properties
 
 - `type` - (required) the type of a control. Set it to `"combo"`
-- `options` - (required) an array of Combo options, each option can be set as a *string* or as an *object* with a set of `key:value` pairs - [attributes of options and their values](#option-properties) 
-- `key` - (optional) the name of the specified/modified property or the path to it in the object of a Diagram item 
+- `options` - (required) an array of Combo options, each option can be set as a *string* or as an *object* with a set of `key:value` pairs - [attributes of options and their values](#option-properties)
+- `key` - (optional) the name of the specified/modified property or the path to it in the object of a Diagram item
 - `wrap` - (optional) allows displaying the external wrapping. *false* by default
 - `css` - (optional) adds style classes to a control
 - `disabled` - (optional) defines whether a control is enabled (*false*) or disabled (*true*). *false* by default
@@ -98,7 +98,7 @@ Option configuration object inside Combo:
 #### Service properties and methods
 
 :::warning
-Note that it's highly not recommended to redefine the service properties and methods for the default types of controls, since it may cause breaks in their functionality. 
+Note that we strongly recommend not redefining the service properties and methods for the default types of controls, since it may cause breaks in their functionality.
 :::
 
 - `$on` - (optional) - allows setting an event listener. The object has the following properties:
@@ -106,12 +106,12 @@ Note that it's highly not recommended to redefine the service properties and met
         - `object` - an object with the following properties:
             - `control` - the [Combo](https://docs.dhtmlx.com/suite/form/combo/) Form control
             - `editor` - the object of the Diagram Editor
-            - `id` - the id of a Diagram item 
+            - `id` - the id of a Diagram item
         - `arguments` - (optional) - the [original event arguments](https://docs.dhtmlx.com/suite/category/form-combo-events/)
 - `$handler` - (optional) - a callback function that allows handling actions on firing the `change` event of the [Combo](https://docs.dhtmlx.com/suite/form/combo/) Form control and the `change` event of DataCollection. Called with the following parameter:
     - `object` - an object with the following properties:
-        - `id` - the id of a Diagram item 
-        - `key` - the name of the specified/modified property or the path to it in the object of a Diagram item 
+        - `id` - the id of a Diagram item
+        - `key` - the name of the specified/modified property or the path to it in the object of a Diagram item
         - `editor` - the object of the Diagram Editor
         - `control` - the object of the [Combo](https://docs.dhtmlx.com/suite/form/combo/) Form control the component is built on
         - `value` - the new value of the [Combo](https://docs.dhtmlx.com/suite/form/combo/) Form control
@@ -119,7 +119,7 @@ Note that it's highly not recommended to redefine the service properties and met
     - `object` - an object with the following properties:
         - `editor` - the object of the Diagram Editor
         - `control` - the object of the [Combo](https://docs.dhtmlx.com/suite/form/combo/) Form control the component is built on
-        - `value` - the value of a Diagram item 
+        - `value` - the value of a Diagram item
 - `$layout` - (optional) - a callback function that allows setting the structure of a control. Returns the configuration of the [Combo](https://docs.dhtmlx.com/suite/form/combo/) Form control. Called with the following parameter:
     - `object` - the configuration of a control without service properties
 

--- a/docs/api/diagram_editor/editbar/basic_controls/container.md
+++ b/docs/api/diagram_editor/editbar/basic_controls/container.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Container
-title: Editbar Basic Controls - Container 
+title: Editbar Basic Controls - Container
 description: You can explore the Container control of Editbar in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Suite.
 ---
 
@@ -17,7 +17,7 @@ description: You can explore the Container control of Editbar in the documentati
     type: "container",
     html: HTMLElement | string,
     wrap?: boolean, // false by default
-    
+
     css?: string,
     disabled?: boolean, // false by default
     hidden?: boolean, // false by default
@@ -55,7 +55,7 @@ description: You can explore the Container control of Editbar in the documentati
 #### Service properties and methods
 
 :::warning
-Note that it's highly not recommended to redefine the service properties and methods for the default types of controls, since it may cause breaks in their functionality. 
+Note that we strongly recommend not redefining the service properties and methods for the default types of controls, since it may cause breaks in their functionality.
 :::
 
 - `$layout` - (optional) - a callback function that allows setting the structure of a control. Returns the configuration of the [Container](https://docs.dhtmlx.com/suite/form/container/) Form control. Called with the following parameter:

--- a/docs/api/diagram_editor/editbar/basic_controls/datepicker.md
+++ b/docs/api/diagram_editor/editbar/basic_controls/datepicker.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Datepicker
-title: Editbar Basic Controls - Datepicker 
+title: Editbar Basic Controls - Datepicker
 description: You can explore the Datepicker control of Editbar in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Suite.
 ---
 
@@ -39,12 +39,12 @@ description: You can explore the Datepicker control of Editbar in the documentat
     weekNumbers?: boolean, // false by default
     weekStart?: "saturday" | "sunday" | "monday", // "sunday" by default
 
-    // for `wrap:true` check the label properties for the Fieldset 
+    // for `wrap:true` check the label properties for the Fieldset
     label?: string,
     labelWidth?: string | number,
     labelPosition?: "left" | "top", // "top" by default
 
-    // service properties and methods 
+    // service properties and methods
     $on?: { [eventName: string]: function },
     $handler?: function,
     $setValue?: function,
@@ -57,7 +57,7 @@ description: You can explore the Datepicker control of Editbar in the documentat
 ### Basic properties
 
 - `type` - (required) the type of a control. Set it to `"datepicker"`
-- `key` - (optional) the name of the specified/modified property or the path to it in the object of a Diagram item 
+- `key` - (optional) the name of the specified/modified property or the path to it in the object of a Diagram item
 - `wrap` - (optional) allows displaying the external wrapping. *false* by default
 - `css` - (optional) adds style classes to a control string
 - `disabled` - (optional) defines whether a control is enabled (*false*) or disabled (*true*). *false* by default
@@ -85,7 +85,7 @@ description: You can explore the Datepicker control of Editbar in the documentat
 ### Service properties and methods
 
 :::warning
-Note that it's highly not recommended to redefine the service properties and methods for the default types of controls, since it may cause breaks in their functionality. 
+Note that we strongly recommend not redefining the service properties and methods for the default types of controls, since it may cause breaks in their functionality.
 :::
 
 - `$on` - (optional) - allows setting an event listener. The object has the following properties:
@@ -93,12 +93,12 @@ Note that it's highly not recommended to redefine the service properties and met
         - `object` - an object with the following properties:
             - `control` - the [Datepicker](https://docs.dhtmlx.com/suite/form/calendar/) Form control
             - `editor` - the object of the Diagram Editor
-            - `id` - the id of a Diagram item 
+            - `id` - the id of a Diagram item
         - `arguments` - (optional) - the [original event arguments](https://docs.dhtmlx.com/suite/category/form-datepicker-events/)
 - `$handler` - (optional) - a callback function that allows handling actions on firing the `change` and `input` events of a form control and the `change` event of DataCollection. Called with the following parameter:
     - `object` - an object with the following properties:
-        - `id` - the id of a Diagram item 
-        - `key` - the name of the specified/modified property or the path to it in the object of a Diagram item 
+        - `id` - the id of a Diagram item
+        - `key` - the name of the specified/modified property or the path to it in the object of a Diagram item
         - `editor` - the object of the Diagram Editor
         - `control` - the object of the [Datepicker](https://docs.dhtmlx.com/suite/form/calendar/) Form control the component is built on
         - `value` - the new value of the [Datepicker](https://docs.dhtmlx.com/suite/form/calendar/) Form control
@@ -106,7 +106,7 @@ Note that it's highly not recommended to redefine the service properties and met
     - `object` - an object with the following properties:
         - `editor` - the object of the Diagram Editor
         - `control` - the object of the [Datepicker](https://docs.dhtmlx.com/suite/form/calendar/) Form control the component is built on
-        - `value` - the value of a Diagram item 
+        - `value` - the value of a Diagram item
 - `$layout` - (optional) - a callback function that allows setting the structure of a control. Returns the configuration of the [Datepicker](https://docs.dhtmlx.com/suite/form/calendar/) Form control. Called with the following parameter:
     - `object` - the configuration of a control without service properties
 

--- a/docs/api/diagram_editor/editbar/basic_controls/fieldset.md
+++ b/docs/api/diagram_editor/editbar/basic_controls/fieldset.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Fieldset
-title: Editbar Basic Controls - Fieldset 
+title: Editbar Basic Controls - Fieldset
 description: You can explore the Fieldset control of Editbar in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Suite.
 ---
 
@@ -71,7 +71,7 @@ The `rows` and `cols` properties may include an array of objects of the specifie
 #### Service properties and methods
 
 :::warning
-Note that it's highly not recommended to redefine the service properties and methods for the default types of controls, since it may cause breaks in their functionality. 
+Note that we strongly recommend not redefining the service properties and methods for the default types of controls, since it may cause breaks in their functionality.
 :::
 
 - `$layout` - (optional) - a callback function that allows setting the structure of a control. Returns the configuration of the [Fieldset](https://docs.dhtmlx.com/suite/form/fieldset/) Form control. Called with the following parameter:

--- a/docs/api/diagram_editor/editbar/basic_controls/input.md
+++ b/docs/api/diagram_editor/editbar/basic_controls/input.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Input
-title: Editbar Basic Controls - Input 
+title: Editbar Basic Controls - Input
 description: You can explore the Input control of Editbar in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Suite.
 ---
 
@@ -17,7 +17,7 @@ description: You can explore the Input control of Editbar in the documentation o
     type: "input",
     key?: string | string[],
     wrap?: boolean, // false by default
-    
+
     css?: string,
     disabled?: boolean, // false by default
     hidden?: boolean, // false by default
@@ -39,7 +39,7 @@ description: You can explore the Input control of Editbar in the documentation o
     labelWidth?: string | number,
     labelPosition?: "left" | "top", // "top" by default
 
-    // service properties and methods 
+    // service properties and methods
     $on?: { [eventName: string]: function },
     $handler?: function,
     $setValue?: function,
@@ -76,7 +76,7 @@ Use the `"password"` value to specify a field for entering a password
 ### Service properties and methods
 
 :::warning
-Note that it's highly not recommended to redefine the service properties and methods for the default types of controls, since it may cause breaks in their functionality. 
+Note that we strongly recommend not redefining the service properties and methods for the default types of controls, since it may cause breaks in their functionality.
 :::
 
 - `$on` - (optional) - allows setting an event listener. The object has the following properties:
@@ -84,12 +84,12 @@ Note that it's highly not recommended to redefine the service properties and met
         - `object` - an object with the following properties:
             - `control` - the [Input](https://docs.dhtmlx.com/suite/form/input/) Form control
             - `editor` - the object of the Diagram Editor
-            - `id` - the id of a Diagram item 
+            - `id` - the id of a Diagram item
         - `arguments` - (optional) - the [original event arguments](https://docs.dhtmlx.com/suite/category/form-input-events/)
 - `$handler` - (optional) - a callback function that allows handling actions on firing the `change` and `input` events of the [Input](https://docs.dhtmlx.com/suite/form/input/) Form control and the `change` event of DataCollection. Called with the following parameter:
     - `object` - an object with the following properties:
-        - `id` - the id of a Diagram item 
-        - `key` - the name of the specified/modified property or the path to it in the object of a Diagram item 
+        - `id` - the id of a Diagram item
+        - `key` - the name of the specified/modified property or the path to it in the object of a Diagram item
         - `editor` - the object of the Diagram Editor
         - `control` - the object of the [Input](https://docs.dhtmlx.com/suite/form/input/) Form control the component is built on
         - `value` - the new value of the [Input](https://docs.dhtmlx.com/suite/form/input/) Form control
@@ -97,7 +97,7 @@ Note that it's highly not recommended to redefine the service properties and met
     - `object` - an object with the following properties:
         - `editor` - the object of the Diagram Editor
         - `control` - the object of the [Input](https://docs.dhtmlx.com/suite/form/input/) Form control the component is built on
-        - `value` - the value of a Diagram item 
+        - `value` - the value of a Diagram item
 - `$layout` - (optional) - a callback function that allows setting the structure of a control. Returns the configuration of the [Input](https://docs.dhtmlx.com/suite/form/input/) Form control. Called with the following parameter:
     - `object` - the configuration of a control without service properties
 

--- a/docs/api/diagram_editor/editbar/basic_controls/radiogroup.md
+++ b/docs/api/diagram_editor/editbar/basic_controls/radiogroup.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: RadioGroup
-title: Editbar Basic Controls - RadioGroup 
+title: Editbar Basic Controls - RadioGroup
 description: You can explore the RadioGroup control of Editbar in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Suite.
 ---
 
@@ -39,7 +39,7 @@ description: You can explore the RadioGroup control of Editbar in the documentat
     labelWidth?: string | number,
     labelPosition?: "left" | "top", // "top" by default
 
-    // service properties and methods 
+    // service properties and methods
     $on?: { [eventName: string]: function },
     $handler?: function,
     $setValue?: function,
@@ -70,7 +70,7 @@ Radio button configuration object inside RadioGroup:
 #### Basic properties
 
 - `type` - (required) the type of a control. Set it to `"radioGroup"`
-- `key` - (optional) the name of the specified/modified property or the path to it in the object of a Diagram item 
+- `key` - (optional) the name of the specified/modified property or the path to it in the object of a Diagram item
 - `wrap` - (optional) allows displaying the external wrapping. *false* by default
 - `options` - (required) an object with options of a RadioGroup. The object can contain the following attributes:
     - `rows` - (optional) arranges [radio buttons](#radio-button-properties) inside the RadioGroup control vertically
@@ -92,7 +92,7 @@ Radio button configuration object inside RadioGroup:
 #### Service properties and methods
 
 :::warning
-Note that it's highly not recommended to redefine the service properties and methods for the default types of controls, since it may cause breaks in their functionality. 
+Note that we strongly recommend not redefining the service properties and methods for the default types of controls, since it may cause breaks in their functionality.
 :::
 
 - `$on` - (optional) - allows setting an event listener. The object has the following properties:
@@ -100,12 +100,12 @@ Note that it's highly not recommended to redefine the service properties and met
         - `object` - an object with the following properties:
             - `control` - the [RadioGroup](https://docs.dhtmlx.com/suite/form/radiogroup/) Form control
             - `editor` - the object of the Diagram Editor
-            - `id` - the id of a Diagram item 
+            - `id` - the id of a Diagram item
         - `arguments` - (optional) - the [original event arguments](https://docs.dhtmlx.com/suite/category/form-radiogroup-events/)
 - `$handler` - (optional) - a callback function that allows handling actions on firing the `change` event of the [RadioGroup](https://docs.dhtmlx.com/suite/form/radiogroup/) Form control and the `change` event of DataCollection. Called with the following parameter:
     - `object` - an object with the following properties:
-        - `id` - the id of a Diagram item 
-        - `key` - the name of the specified/modified property or the path to it in the object of a Diagram item 
+        - `id` - the id of a Diagram item
+        - `key` - the name of the specified/modified property or the path to it in the object of a Diagram item
         - `editor` - the object of the Diagram Editor
         - `control` - the object of the [RadioGroup](https://docs.dhtmlx.com/suite/form/radiogroup/) Form control the component is built on
         - `value` - the new value of the [RadioGroup](https://docs.dhtmlx.com/suite/form/radiogroup/) Form control
@@ -113,11 +113,11 @@ Note that it's highly not recommended to redefine the service properties and met
     - `object` - an object with the following properties:
         - `editor` - the object of the Diagram Editor
         - `control` - the object of the [RadioGroup](https://docs.dhtmlx.com/suite/form/radiogroup/) Form control the component is built on
-        - `value` - the value of a Diagram item 
+        - `value` - the value of a Diagram item
 - `$layout` - (optional) - a callback function that allows setting the structure of a control. Returns the configuration of the [RadioGroup](https://docs.dhtmlx.com/suite/form/radiogroup/) Form control. Called with the following parameter:
     - `object` - the configuration of a control without service properties
 
-### Radio button properties 
+### Radio button properties
 
 - `value` - (required) the value of a radio button
 - `text` - (optional) the text label of a radio button

--- a/docs/api/diagram_editor/editbar/basic_controls/select.md
+++ b/docs/api/diagram_editor/editbar/basic_controls/select.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Select
-title: Editbar Basic Controls - Select 
+title: Editbar Basic Controls - Select
 description: You can explore the Select control of Editbar in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Suite.
 ---
 
@@ -24,7 +24,7 @@ description: You can explore the Select control of Editbar in the documentation 
     hidden?: boolean, // false by default
     height?: string | number | "content", // "content" by default
     width?: string | number | "content", // "content" by default
-    padding?: string | number, 
+    padding?: string | number,
     icon?: string,
 
     // for `wrap:true` check the label properties for the Fieldset
@@ -32,7 +32,7 @@ description: You can explore the Select control of Editbar in the documentation 
     labelWidth?: string | number,
     labelPosition?: "left" | "top", // "top" by default
 
-    // service properties and methods 
+    // service properties and methods
     $on?: { [eventName: string]: function },
     $handler?: function,
     $setValue?: function,
@@ -58,7 +58,7 @@ Option configuration object inside Select:
 
 - `type` - (required) the type of a control. Set it to `"select"`
 - `options` - (required) an array of Select options, each option can be set as a *string* or as an *object* with a set of `key:value` pairs - [attributes of options and their values](#option-properties)
-- `key` - (optional) the name of the specified/modified property or the path to it in the object of a Diagram item 
+- `key` - (optional) the name of the specified/modified property or the path to it in the object of a Diagram item
 - `wrap` - (optional) allows displaying the external wrapping. *false* by default
 - `css` - (optional) adds style classes to a control
 - `disabled` - (optional) defines whether a control is enabled (*false*) or disabled (*true*). *false* by default
@@ -74,7 +74,7 @@ Option configuration object inside Select:
 #### Service properties and methods
 
 :::warning
-Note that it's highly not recommended to redefine the service properties and methods for the default types of controls, since it may cause breaks in their functionality. 
+Note that we strongly recommend not redefining the service properties and methods for the default types of controls, since it may cause breaks in their functionality.
 :::
 
 - `$on` - (optional) - allows setting an event listener. The object has the following properties:
@@ -82,11 +82,11 @@ Note that it's highly not recommended to redefine the service properties and met
         - `object` - an object with the following properties:
             - `control` - the [Select](https://docs.dhtmlx.com/suite/form/select/) Form control
             - `editor` - the object of the Diagram Editor
-            - `id` - the id of a Diagram item 
+            - `id` - the id of a Diagram item
         - `arguments` - (optional) - the [original event arguments](https://docs.dhtmlx.com/suite/category/form-select-events/)
 - `$handler` - (optional) - a callback function that allows handling actions on firing the `change` event of the [Select](https://docs.dhtmlx.com/suite/form/select/) Form control and the `change` event of DataCollection. Called with the following parameter:
     - `object` - an object with the following properties:
-        - `id` - the id of a Diagram item 
+        - `id` - the id of a Diagram item
         - `key` - the name of the specified/modified property or the path to it in the object of a Diagram item
         - `editor` - the object of the Diagram Editor
         - `control` - the object of the [Select](https://docs.dhtmlx.com/suite/form/select/) Form control the component is built on
@@ -95,7 +95,7 @@ Note that it's highly not recommended to redefine the service properties and met
     - `object` - an object with the following properties:
         - `editor` - the object of the Diagram Editor
         - `control` - the object of the [Select](https://docs.dhtmlx.com/suite/form/select/) Form control the component is built on
-        - `value` - the value of a Diagram item 
+        - `value` - the value of a Diagram item
 - `$layout` - (optional) - a callback function that allows setting the structure of a control. Returns the configuration of the [Select](https://docs.dhtmlx.com/suite/form/select/) Form control. Called with the following parameter:
     - `object` - the configuration of a control without service properties
 

--- a/docs/api/diagram_editor/editbar/basic_controls/slider.md
+++ b/docs/api/diagram_editor/editbar/basic_controls/slider.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Slider
-title: Editbar Basic Controls - Slider 
+title: Editbar Basic Controls - Slider
 description: You can explore the Slider control of Editbar in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Suite.
 ---
 
@@ -17,12 +17,12 @@ description: You can explore the Slider control of Editbar in the documentation 
     type: "slider",
     key?: string | string[],
     wrap?: boolean, // false by default
-   
+
     disabled?: boolean, // false by default
     hidden?: boolean, // false by default
     css?: string,
     padding?: string | number,
-    height?: string | number | "content", // "content" by default   
+    height?: string | number | "content", // "content" by default
     width?: string | number | "content", // "content" by default
 
     inverse?: boolean, // false by default
@@ -35,13 +35,13 @@ description: You can explore the Slider control of Editbar in the documentation 
     tick?: number,
     tickTemplate?: (position: number) => string,
     tooltip?: boolean, // true by default
-    
+
     // for `wrap:true` check the label properties for the Fieldset
     label?: string,
     labelWidth?: string | number,
     labelPosition?: "left" | "top", // "top" by default
 
-    // service properties and methods 
+    // service properties and methods
     $on?: { [eventName: string]: function },
     $handler?: function,
     $setValue?: function,
@@ -54,7 +54,7 @@ description: You can explore the Slider control of Editbar in the documentation 
 ### Basic properties
 
 - `type` - (required) the type of a control. Set it to `"slider"`
-- `key` - (optional) the name of the specified/modified property or the path to it in the object of a Diagram item 
+- `key` - (optional) the name of the specified/modified property or the path to it in the object of a Diagram item
 - `wrap` - (optional) allows displaying the external wrapping. *false* by default
 - `disabled` - (optional) defines whether a control is enabled (*false*) or disabled (*true*). *false* by default
 - `hidden` - (optional) defines whether a control is hidden. *false* by default
@@ -67,7 +67,7 @@ description: You can explore the Slider control of Editbar in the documentation 
 - `max` - (optional) the maximal value of slider. *100* by default
 - `min` - (optional) the minimal value of slider. *0* by default
 - `mode` - (optional) the direction of the slider scale. `"horizontal"` by default
-- `range` - (optional) enables/disables the possibility to select a range of values on the slider. *false* by default
+- `range` - (optional) enables/disables selecting a range of values on the slider. *false* by default
 - `step` - (optional) the step the slider thumb will be moved with. *1* by default
 - `tick` - (optional) sets the interval of steps for rendering the slider scale
 - `tickTemplate` - (optional) sets a template for rendering values on the scale
@@ -76,7 +76,7 @@ description: You can explore the Slider control of Editbar in the documentation 
 ### Service properties and methods
 
 :::warning
-Note that it's highly not recommended to redefine the service properties and methods for the default types of controls, since it may cause breaks in their functionality. 
+Note that we strongly recommend not redefining the service properties and methods for the default types of controls, since it may cause breaks in their functionality.
 :::
 
 - `$on` - (optional) - allows setting an event listener. The object has the following properties:
@@ -84,12 +84,12 @@ Note that it's highly not recommended to redefine the service properties and met
         - `object` - an object with the following properties:
             - `control` - the [Slider](https://docs.dhtmlx.com/suite/form/slider/) Form control
             - `editor` - the object of the Diagram Editor
-            - `id` - the id of a Diagram item 
+            - `id` - the id of a Diagram item
         - `arguments` - (optional) - the [original event arguments](https://docs.dhtmlx.com/suite/category/form-slider-events/)
 - `$handler` - (optional) - a callback function that allows handling actions on firing the `change` event of the [Slider](https://docs.dhtmlx.com/suite/form/slider/) Form control and the `change` event of DataCollection. Called with the following parameter:
     - `object` - an object with the following properties:
-        - `id` - the id of a Diagram item 
-        - `key` - the name of the specified/modified property or the path to it in the object of a Diagram item 
+        - `id` - the id of a Diagram item
+        - `key` - the name of the specified/modified property or the path to it in the object of a Diagram item
         - `editor` - the object of the Diagram Editor
         - `control` - the object of the [Slider](https://docs.dhtmlx.com/suite/form/slider/) Form control the component is built on
         - `value` - the new value of the [Slider](https://docs.dhtmlx.com/suite/form/slider/) Form control
@@ -97,7 +97,7 @@ Note that it's highly not recommended to redefine the service properties and met
     - `object` - an object with the following properties:
         - `editor` - the object of the Diagram Editor
         - `control` - the object of the [Slider](https://docs.dhtmlx.com/suite/form/slider/) Form control the component is built on
-        - `value` - the value of a Diagram item 
+        - `value` - the value of a Diagram item
 - `$layout` - (optional) - a callback function that allows setting the structure of a control. Returns the configuration of the [Slider](https://docs.dhtmlx.com/suite/form/slider/) Form control. Called with the following parameter:
     - `object` - the configuration of a control without service properties
 

--- a/docs/api/diagram_editor/editbar/basic_controls/spacer.md
+++ b/docs/api/diagram_editor/editbar/basic_controls/spacer.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Spacer
-title: Editbar Basic Controls - Spacer 
+title: Editbar Basic Controls - Spacer
 description: You can explore the Spacer control of Editbar in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Suite.
 ---
 

--- a/docs/api/diagram_editor/editbar/basic_controls/textarea.md
+++ b/docs/api/diagram_editor/editbar/basic_controls/textarea.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Textarea
-title: Editbar Basic Controls - Textarea 
+title: Editbar Basic Controls - Textarea
 description: You can explore the Textarea control of Editbar in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Suite.
 ---
 
@@ -17,7 +17,7 @@ description: You can explore the Textarea control of Editbar in the documentatio
     type: "textarea",
     key?: string | string[],
     wrap?: boolean, // false by default
-    
+
     css?: string,
     disabled?: boolean, // false by default
     hidden?: boolean, // false by default
@@ -27,7 +27,7 @@ description: You can explore the Textarea control of Editbar in the documentatio
 
     maxlength?: number | string,
     minlength?: number | string,
-    placeholder?: string, 
+    placeholder?: string,
     readOnly?: boolean, // false by default
 
     // for `wrap:true` check the label properties for the Fieldset
@@ -35,7 +35,7 @@ description: You can explore the Textarea control of Editbar in the documentatio
     labelWidth?: string | number,
     labelPosition?: "left" | "top", // "top" by default
 
-    // service properties and methods 
+    // service properties and methods
     $on?: { [eventName: string]: function },
     $handler?: function,
     $setValue?: function,
@@ -48,7 +48,7 @@ description: You can explore the Textarea control of Editbar in the documentatio
 ### Basic properties
 
 - `type` - (required) the type of a control. Set it to `"textarea"`
-- `key` - (optional) the name of the specified/modified property or the path to it in the object of a Diagram item 
+- `key` - (optional) the name of the specified/modified property or the path to it in the object of a Diagram item
 - `wrap` - (optional) allows displaying the external wrapping. *false* by default
 - `css` - (optional) adds style classes to a control
 - `hidden` - (optional) defines whether a control is hidden. *false* by default
@@ -67,7 +67,7 @@ description: You can explore the Textarea control of Editbar in the documentatio
 ### Service properties and methods
 
 :::warning
-Note that it's highly not recommended to redefine the service properties and methods for the default types of controls, since it may cause breaks in their functionality. 
+Note that we strongly recommend not redefining the service properties and methods for the default types of controls, since it may cause breaks in their functionality.
 :::
 
 - `$on` - (optional) - allows setting an event listener. The object has the following properties:
@@ -75,12 +75,12 @@ Note that it's highly not recommended to redefine the service properties and met
         - `object` - an object with the following properties:
             - `control` - the [Textarea](https://docs.dhtmlx.com/suite/form/textarea/) Form control
             - `editor` - the object of the Diagram Editor
-            - `id` - the id of a Diagram item 
+            - `id` - the id of a Diagram item
         - `arguments` - (optional) - the [original event arguments](https://docs.dhtmlx.com/suite/category/form-textarea-events/)
 - `$handler` - (optional) - a callback function that allows handling actions on firing the `change` and `input` events of the [Textarea](https://docs.dhtmlx.com/suite/form/textarea/) Form control and the `change` event of DataCollection. Called with the following parameter:
     - `object` - an object with the following properties:
-        - `id` - the id of a Diagram item 
-        - `key` - the name of the specified/modified property or the path to it in the object of a Diagram item 
+        - `id` - the id of a Diagram item
+        - `key` - the name of the specified/modified property or the path to it in the object of a Diagram item
         - `editor` - the object of the Diagram Editor
         - `control` - the object of the [Textarea](https://docs.dhtmlx.com/suite/form/textarea/) Form control the component is built on
         - `value` - the new value of the [Textarea](https://docs.dhtmlx.com/suite/form/textarea/) Form control
@@ -88,7 +88,7 @@ Note that it's highly not recommended to redefine the service properties and met
     - `object` - an object with the following properties:
         - `editor` - the object of the Diagram Editor
         - `control` - the object of the [Textarea](https://docs.dhtmlx.com/suite/form/textarea/) Form control the component is built on
-        - `value` - the value of a Diagram item 
+        - `value` - the value of a Diagram item
 - `$layout` - (optional) - a callback function that allows setting the structure of a control. Returns the configuration of the [Textarea](https://docs.dhtmlx.com/suite/form/textarea/) Form control. Called with the following parameter:
     - `object` - the configuration of a control without service properties
 

--- a/docs/api/diagram_editor/editbar/basic_controls/timepicker.md
+++ b/docs/api/diagram_editor/editbar/basic_controls/timepicker.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Timepicker
-title: Editbar Basic Controls - Timepicker 
+title: Editbar Basic Controls - Timepicker
 description: You can explore the Timepicker control of Editbar in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Suite.
 ---
 
@@ -24,7 +24,7 @@ description: You can explore the Timepicker control of Editbar in the documentat
     height?: string | number | "content", // "content" by default
     width?: string | number | "content", // "content" by default
     padding?: string | number,
-    
+
     controls?: boolean, // false by default
     icon?: string,
     placeholder?: string,
@@ -36,7 +36,7 @@ description: You can explore the Timepicker control of Editbar in the documentat
     labelWidth?: string | number,
     labelPosition?: "left" | "top", // "top" by default
 
-    // service properties and methods 
+    // service properties and methods
     $on?: { [eventName: string]: function },
     $handler?: function,
     $setValue?: function,
@@ -49,7 +49,7 @@ description: You can explore the Timepicker control of Editbar in the documentat
 ### Basic properties
 
 - `type` - (required) the type of a control. Set it to `"timepicker"`
-- `key` - (optional) the name of the specified/modified property or the path to it in the object of a Diagram item 
+- `key` - (optional) the name of the specified/modified property or the path to it in the object of a Diagram item
 - `wrap` - (optional) allows displaying the external wrapping. *false* by default
 - `css` - (optional) adds style classes to a control
 - `hidden` - (optional) defines whether a control is hidden. *false* by default
@@ -69,7 +69,7 @@ description: You can explore the Timepicker control of Editbar in the documentat
 ### Service properties and methods
 
 :::warning
-Note that it's highly not recommended to redefine the service properties and methods for the default types of controls, since it may cause breaks in their functionality. 
+Note that we strongly recommend not redefining the service properties and methods for the default types of controls, since it may cause breaks in their functionality.
 :::
 
 - `$on` - (optional) - allows setting an event listener. The object has the following properties:
@@ -77,12 +77,12 @@ Note that it's highly not recommended to redefine the service properties and met
         - `object` - an object with the following properties:
             - `control` - the [Timepicker](https://docs.dhtmlx.com/suite/form/timepicker/) Form control
             - `editor` - the object of the Diagram Editor
-            - `id` - the id of a Diagram item 
+            - `id` - the id of a Diagram item
         - `arguments` - (optional) - the [original event arguments](https://docs.dhtmlx.com/suite/category/form-timepicker-events/)
 - `$handler` - (optional) - a callback function that allows handling actions on firing the `change` and `input` events of the [Timepicker](https://docs.dhtmlx.com/suite/form/timepicker/) Form control and the `change` event of DataCollection. Called with the following parameter:
     - `object` - an object with the following properties:
-        - `id` - the id of a Diagram item 
-        - `key` - the name of the specified/modified property or the path to it in the object of a Diagram item 
+        - `id` - the id of a Diagram item
+        - `key` - the name of the specified/modified property or the path to it in the object of a Diagram item
         - `editor` - the object of the Diagram Editor
         - `control` - the object of the [Timepicker](https://docs.dhtmlx.com/suite/form/timepicker/) Form control the component is built on
         - `value` - the new value of the [Timepicker](https://docs.dhtmlx.com/suite/form/timepicker/) Form control
@@ -90,7 +90,7 @@ Note that it's highly not recommended to redefine the service properties and met
     - `object` - an object with the following properties:
         - `editor` - the object of the Diagram Editor
         - `control` - the object of the [Timepicker](https://docs.dhtmlx.com/suite/form/timepicker/) Form control the component is built on
-        - `value` - the value of a Diagram item 
+        - `value` - the value of a Diagram item
 - `$layout` - (optional) - a callback function that allows setting the structure of a control. Returns the configuration of the [Timepicker](https://docs.dhtmlx.com/suite/form/timepicker/) Form control. Called with the following parameter:
     - `object` - the configuration of a control without service properties
 

--- a/docs/api/diagram_editor/editbar/basic_controls/toggle.md
+++ b/docs/api/diagram_editor/editbar/basic_controls/toggle.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Toggle
-title: Editbar Basic Controls - Toggle 
+title: Editbar Basic Controls - Toggle
 description: You can explore the Toggle control of Editbar in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Suite.
 ---
 
@@ -32,7 +32,7 @@ description: You can explore the Toggle control of Editbar in the documentation 
     height?: string | number | "content", // "content" by default
     padding?: string | number,
 
-    // service properties and methods 
+    // service properties and methods
     $on?: { [eventName: string]: function },
     $handler?: function,
     $setValue?: function,
@@ -47,15 +47,15 @@ The control can be used both with the *boolean* value and the *string* one, if t
 ### Basic properties
 
 - `type` - (required) the type of a control. Set it to `"toggle"`
-- `key` - (optional) the name of the specified/modified property or the path to it in the object of a Diagram item  
+- `key` - (optional) the name of the specified/modified property or the path to it in the object of a Diagram item
 - `hidden` - (optional) defines whether a control is hidden. *false* by default
 - `disabled` - (optional) defines whether a control is enabled (*false*) or disabled (*true*). *false* by default
 - `full` - (optional) defines whether the toggle will be extended to the width specified by the `width` property. *false* by default
-- `text` - (optional) sets a text inside the toggle. When initialized together with the `offText` property, the specified text will be rendered in the selected (pressed) state
+- `text` - (optional) sets text inside the toggle. When initialized together with the `offText` property, the specified text will be rendered in the selected (pressed) state
 - `offText` - (optional) sets the text that will be rendered in the unselected (unpressed) state of the toggle
 - `icon` - (optional) sets the CSS class of an icon displayed inside the toggle. When initialized together with the `offIcon` property, the specified CSS classes of icons will be rendered in the selected (pressed) state of the toggle
 - `offIcon` - (optional) sets the CSS class of an icon that will be rendered in the unselected (unpressed) state of the toggle
-- `value` - (optional) specifies the value in the selected (pressed) state. If not defined, the control is used with the *boolean* value 
+- `value` - (optional) specifies the value in the selected (pressed) state. If not defined, the control is used with the *boolean* value
 - `css` - (optional) adds style classes to a control
 - `width` - (optional) the width of a control. `"content"` by default
 - `height` - (optional) the height of a control. `"content"` by default
@@ -64,7 +64,7 @@ The control can be used both with the *boolean* value and the *string* one, if t
 ### Service properties and methods
 
 :::warning
-Note that it's highly not recommended to redefine the service properties and methods for the default types of controls, since it may cause breaks in their functionality. 
+Note that we strongly recommend not redefining the service properties and methods for the default types of controls, since it may cause breaks in their functionality.
 :::
 
 - `$on` - (optional) - allows setting an event listener. The object has the following properties:
@@ -72,12 +72,12 @@ Note that it's highly not recommended to redefine the service properties and met
         - `object` - an object with the following properties:
             - `control` - the [Toggle](https://docs.dhtmlx.com/suite/form/toggle/) Form control
             - `editor` - the object of the Diagram Editor
-            - `id` - the id of a Diagram item 
+            - `id` - the id of a Diagram item
         - `arguments` - (optional) - the [original event arguments](https://docs.dhtmlx.com/suite/category/form-toggle-events/)
 - `$handler` - (optional) - a callback function that allows handling actions on firing the `change` event of the [Toggle](https://docs.dhtmlx.com/suite/form/toggle/) Form control and the `change` event of DataCollection. Called with the following parameter:
     - `object` - an object with the following properties:
-        - `id` - the id of a Diagram item 
-        - `key` - the name of the specified/modified property or the path to it in the object of a Diagram item 
+        - `id` - the id of a Diagram item
+        - `key` - the name of the specified/modified property or the path to it in the object of a Diagram item
         - `editor` - the object of the Diagram Editor
         - `control` - the object of the [Toggle](https://docs.dhtmlx.com/suite/form/toggle/) Form control the component is built on
         - `value` - the new value of the [Toggle](https://docs.dhtmlx.com/suite/form/toggle/) Form control
@@ -85,7 +85,7 @@ Note that it's highly not recommended to redefine the service properties and met
     - `object` - an object with the following properties:
         - `editor` - the object of the Diagram Editor
         - `control` - the object of the [Toggle](https://docs.dhtmlx.com/suite/form/toggle/) Form control the component is built on
-        - `value` - the value of a Diagram item 
+        - `value` - the value of a Diagram item
 - `$layout` - (optional) - a callback function that allows setting the structure of a control. Returns the configuration of the [Toggle](https://docs.dhtmlx.com/suite/form/toggle/) Form control. Called with the following parameter:
     - `object` - the configuration of a control without service properties
 
@@ -124,7 +124,7 @@ const editor= new dhx.DiagramEditor("editor_container", {
                         type: "toggle",
                         key: "fontStyle",
                         value: "italic",
-                        icon: "dxi dxi-format-italic"        
+                        icon: "dxi dxi-format-italic"
                     }
                 ]
             }

--- a/docs/api/diagram_editor/editbar/basic_controls/togglegroup.md
+++ b/docs/api/diagram_editor/editbar/basic_controls/togglegroup.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: ToggleGroup
-title: Editbar Basic Controls - ToggleGroup 
+title: Editbar Basic Controls - ToggleGroup
 description: You can explore the ToggleGroup control of Editbar in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Suite.
 ---
 
@@ -21,14 +21,14 @@ description: You can explore the ToggleGroup control of Editbar in the documenta
     full?: boolean, // false by default
     gap?: number, // 0 by default
     hidden?: boolean, // false by default
-    disabled?: boolean, // false by default  
+    disabled?: boolean, // false by default
 
     css?: string,
     width?: string | number | "content", // "content" by default
     height?: string | number | "content", // "content" by default
     padding?: string | number,
 
-    // service properties and methods 
+    // service properties and methods
     $on?: { [eventName: string]: function },
     $handler?: function,
     $setValue?: function,
@@ -61,7 +61,7 @@ The objects with the `toggle` configuration inside the control can be used both 
 #### Basic properties
 
 - `type` - (required) the type of a control. Set it to `"toggleGroup"`
-- `key` - (optional) the name of the specified/modified property or the path to it in the object of a Diagram item 
+- `key` - (optional) the name of the specified/modified property or the path to it in the object of a Diagram item
 - `options` - (required) an array of ToggleGroup options, each option is set as an *object* with a set of `key:value` pairs - [attributes of options and their values](#toggle-properties)
 - `hidden` - (optional) defines whether a ToggleGroup is hidden. *false* by default
 - `disabled` - (optional) defines whether a control is enabled (*false*) or disabled (*true*). *false* by default
@@ -75,7 +75,7 @@ The objects with the `toggle` configuration inside the control can be used both 
 #### Service properties and methods
 
 :::warning
-Note that it's highly not recommended to redefine the service properties and methods for the default types of controls, since it may cause breaks in their functionality. 
+Note that we strongly recommend not redefining the service properties and methods for the default types of controls, since it may cause breaks in their functionality.
 :::
 
 - `$on` - (optional) - allows setting an event listener. The object has the following properties:
@@ -83,12 +83,12 @@ Note that it's highly not recommended to redefine the service properties and met
         - `object` - an object with the following properties:
             - `control` - the [ToggleGroup](https://docs.dhtmlx.com/suite/form/togglegroup/) Form control
             - `editor` - the object of the Diagram Editor
-            - `id` - the id of a Diagram item 
+            - `id` - the id of a Diagram item
         - `arguments` - (optional) - the [original event arguments](https://docs.dhtmlx.com/suite/category/form-togglegroup-events/)
 - `$handler` - (optional) - a callback function that allows handling actions on firing the `change` event of the [ToggleGroup](https://docs.dhtmlx.com/suite/form/togglegroup/) Form control and the `change` event of DataCollection. Called with the following parameter:
     - `object` - an object with the following properties:
-        - `id` - the id of a Diagram item 
-        - `key` - the name of the specified/modified property or the path to it in the object of a Diagram item 
+        - `id` - the id of a Diagram item
+        - `key` - the name of the specified/modified property or the path to it in the object of a Diagram item
         - `editor` - the object of the Diagram Editor
         - `control` - the object of the [ToggleGroup](https://docs.dhtmlx.com/suite/form/togglegroup/) Form control the component is built on
         - `value` - the new value of the [ToggleGroup](https://docs.dhtmlx.com/suite/form/togglegroup/) Form control
@@ -96,7 +96,7 @@ Note that it's highly not recommended to redefine the service properties and met
     - `object` - an object with the following properties:
         - `editor` - the object of the Diagram Editor
         - `control` - the object of the [ToggleGroup](https://docs.dhtmlx.com/suite/form/togglegroup/) Form control the component is built on
-        - `value` - the value of a Diagram item 
+        - `value` - the value of a Diagram item
 - `$layout` - (optional) - a callback function that allows setting the structure of a control. Returns the configuration of the [ToggleGroup](https://docs.dhtmlx.com/suite/form/togglegroup/) Form control. Called with the following parameter:
     - `object` - the configuration of a control without service properties
 
@@ -106,7 +106,7 @@ Note that it's highly not recommended to redefine the service properties and met
 - `hidden` - (optional) defines whether an option is hidden. *false* by default
 - `disabled` - (optional) defines whether an option is enabled (*false*) or disabled (*true*). *false* by default
 - `full` - (optional) defines whether the option will be extended to the width specified by the `width` property. *false* by default
-- `text` - (optional) sets a text inside the option. When initialized together with the `offText` property, the specified text will be rendered in the selected (pressed) state
+- `text` - (optional) sets text inside the option. When initialized together with the `offText` property, the specified text will be rendered in the selected (pressed) state
 - `icon` - (optional) sets the CSS class of an icon displayed inside the option. When initialized together with the `offIcon` property, the specified CSS classes of icons will be rendered in the selected (pressed) state of the option
 - `offText` - (optional) sets the text that will be rendered in the unselected (unpressed) state of the option
 - `offIcon` - (optional) sets the CSS class of an icon that will be rendered in the unselected (unpressed) state of the option

--- a/docs/api/diagram_editor/editbar/complex_controls/arrange.md
+++ b/docs/api/diagram_editor/editbar/complex_controls/arrange.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Arrange
-title: Editbar Complex Controls - Arrange 
-description: You can explore the Arrange control of Editbar in the documentation of the the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Suite.
+title: Editbar Complex Controls - Arrange
+description: You can explore the Arrange control of Editbar in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Suite.
 ---
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
@@ -37,7 +37,7 @@ The **Arrange** control is available for all elements (excluding the `line` and 
     labelAlignment?: "left" | "right" | "center", // "left" by default
     align?: "start" | "center" | "end" | "between" | "around" | "evenly", // "start" by default
     compact?: boolean, // false by default
-   
+
     // Service properties
     $properties?: object
 }

--- a/docs/api/diagram_editor/editbar/complex_controls/border.md
+++ b/docs/api/diagram_editor/editbar/complex_controls/border.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Border
-title: Editbar Complex Controls - Border 
-description: You can explore the Border control of Editbar in the documentation of the the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Suite.
+title: Editbar Complex Controls - Border
+description: You can explore the Border control of Editbar in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Suite.
 ---
 
 import useBaseUrl from '@docusaurus/useBaseUrl';

--- a/docs/api/diagram_editor/editbar/complex_controls/gridstep.md
+++ b/docs/api/diagram_editor/editbar/complex_controls/gridstep.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Grid step
-title: Editbar Complex Controls - Grid step 
-description: You can explore the Grid step control of Editbar in the documentation of the the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Suite.
+title: Editbar Complex Controls - Grid step
+description: You can explore the Grid step control of Editbar in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Suite.
 ---
 
 import useBaseUrl from '@docusaurus/useBaseUrl';

--- a/docs/api/diagram_editor/editbar/complex_controls/header.md
+++ b/docs/api/diagram_editor/editbar/complex_controls/header.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Header
-title: Editbar Complex Controls - Header 
-description: You can explore the Header control of Editbar in the documentation of the the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Suite.
+title: Editbar Complex Controls - Header
+description: You can explore the Header control of Editbar in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Suite.
 ---
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
@@ -65,9 +65,9 @@ const editor= new dhx.DiagramEditor("editor_container", {
         editbar: {
             properties: {
                 $group: [
-                    { 
-                        type: "header", 
-                        label: "Group header style" 
+                    {
+                        type: "header",
+                        label: "Group header style"
                     }
                 ]
             }

--- a/docs/api/diagram_editor/editbar/complex_controls/headercommon.md
+++ b/docs/api/diagram_editor/editbar/complex_controls/headercommon.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Header common
-title: Editbar Complex Controls - Header common 
-description: You can explore the Header common control of Editbar in the documentation of the the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Suite.
+title: Editbar Complex Controls - Header common
+description: You can explore the Header common control of Editbar in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Suite.
 ---
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
@@ -37,7 +37,7 @@ The **Header common** control is available only for `group` and `swimlane` eleme
     labelAlignment?: "left" | "right" | "center", // "left" by default
     align?: "start" | "center" | "end" | "between" | "around" | "evenly", // "between" by default
     compact?: boolean, // false by default
-   
+
     // Service properties
     $properties?: object
 }

--- a/docs/api/diagram_editor/editbar/complex_controls/headerposition.md
+++ b/docs/api/diagram_editor/editbar/complex_controls/headerposition.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Header position
-title: Editbar Complex Controls - Header position 
-description: You can explore the Header position control of Editbar in the documentation of the the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Suite.
+title: Editbar Complex Controls - Header position
+description: You can explore the Header position control of Editbar in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Suite.
 ---
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
@@ -37,7 +37,7 @@ The **Header position** control is available only for `group` and `swimlane` ele
     labelAlignment?: "left" | "right" | "center", // "left" by default
     align?: "start" | "center" | "end" | "between" | "around" | "evenly", // "start" by default
     compact?: boolean, // false by default
-   
+
     // Service properties
     $properties?: object
 }

--- a/docs/api/diagram_editor/editbar/complex_controls/lineshape.md
+++ b/docs/api/diagram_editor/editbar/complex_controls/lineshape.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Line shape
-title: Editbar Complex Controls - Line shape 
-description: You can explore the Line shape control of Editbar in the documentation of the the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Suite.
+title: Editbar Complex Controls - Line shape
+description: You can explore the Line shape control of Editbar in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Suite.
 ---
 
 import useBaseUrl from '@docusaurus/useBaseUrl';

--- a/docs/api/diagram_editor/editbar/complex_controls/pointerview.md
+++ b/docs/api/diagram_editor/editbar/complex_controls/pointerview.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Pointer view
-title: Editbar Complex Controls - Pointer view 
-description: You can explore the Pointer view control of Editbar in the documentation of the the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Suite.
+title: Editbar Complex Controls - Pointer view
+description: You can explore the Pointer view control of Editbar in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Suite.
 ---
 
 import useBaseUrl from '@docusaurus/useBaseUrl';

--- a/docs/api/diagram_editor/editbar/complex_controls/position.md
+++ b/docs/api/diagram_editor/editbar/complex_controls/position.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Position
-title: Editbar Complex Controls - Position 
-description: You can explore the Position control of Editbar in the documentation of the the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Suite.
+title: Editbar Complex Controls - Position
+description: You can explore the Position control of Editbar in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Suite.
 ---
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
@@ -36,7 +36,7 @@ The **Position** control is available only for the `shape` element in the *org* 
     label?: string,
     labelAlignment?: "left" | "right" | "center", // "left" by default
     align?: "start" | "center" | "end" | "between" | "around" | "evenly", // "start" by default
-    compact?: boolean, // false by default 
+    compact?: boolean, // false by default
 
     // Service properties
     $properties?: object

--- a/docs/api/diagram_editor/editbar/complex_controls/size.md
+++ b/docs/api/diagram_editor/editbar/complex_controls/size.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Size
-title: Editbar Complex Controls - Size 
-description: You can explore the Size control of Editbar in the documentation of the the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Suite.
+title: Editbar Complex Controls - Size
+description: You can explore the Size control of Editbar in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Suite.
 ---
 
 import useBaseUrl from '@docusaurus/useBaseUrl';

--- a/docs/api/diagram_editor/editbar/complex_controls/textalign.md
+++ b/docs/api/diagram_editor/editbar/complex_controls/textalign.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Text align
-title: Editbar Complex Controls - Text align 
-description: You can explore the Text align control of Editbar in the documentation of the the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Suite.
+title: Editbar Complex Controls - Text align
+description: You can explore the Text align control of Editbar in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Suite.
 ---
 
 import useBaseUrl from '@docusaurus/useBaseUrl';

--- a/docs/api/diagram_editor/editbar/complex_controls/textstyle.md
+++ b/docs/api/diagram_editor/editbar/complex_controls/textstyle.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Text style
-title: Editbar Complex Controls - Text style 
-description: You can explore the Text style control of Editbar in the documentation of the the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Suite.
+title: Editbar Complex Controls - Text style
+description: You can explore the Text style control of Editbar in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Suite.
 ---
 
 import useBaseUrl from '@docusaurus/useBaseUrl';

--- a/docs/api/diagram_editor/editbar/complex_controls_overview.md
+++ b/docs/api/diagram_editor/editbar/complex_controls_overview.md
@@ -6,7 +6,7 @@ description: You can learn about the Complex controls of Editbar in the document
 
 # Complex controls
 
-You can use complex controls of Editbar standalone or create complex controls on their base. Below you'll find the list of complex controls. Check the corresponding section to view the detailed description of configuration properties for each control.
+You can use complex controls of Editbar to configure the Editbar for Diagram items. Below you'll find the list of complex controls. Check the corresponding section to view the detailed description of configuration properties for each control.
 
 :::info
 Refer to the [Editbar configuration](guides/diagram_editor/editbar.md) guide for more information about configuring!

--- a/docs/api/diagram_editor/editbar/config/controls_property.md
+++ b/docs/api/diagram_editor/editbar/config/controls_property.md
@@ -60,7 +60,7 @@ const editor = new dhx.DiagramEditor("editor_container", {
             },
             controls: {
                 // create the "estimate" custom control
-                estimate: { 
+                estimate: {
                     type: "fieldset",
                     label: "Time estimate",
                     rows: [

--- a/docs/api/diagram_editor/editbar/config/properties_property.md
+++ b/docs/api/diagram_editor/editbar/config/properties_property.md
@@ -23,7 +23,7 @@ Refer to the [**Editbar configuration**](guides/diagram_editor/editbar.md) guide
 
 ~~~jsx
 properties?: {
-    [type: string]: object[] | function, // custom configurations for controls applied to Diagram elements 
+    [type: string]: object[] | function, // custom configurations for controls applied to Diagram elements
 };
 ~~~
 
@@ -62,9 +62,9 @@ You can also configure Editbar controls for a separate group of Diagram elements
 
 ~~~jsx
 properties: {
-    $default: [], 
-    $shape: [], 
-    $group: [], 
+    $default: [],
+    $shape: [],
+    $group: [],
     $swimlane: [],
     $line: [],
     $lineTitle: [],

--- a/docs/api/diagram_editor/editor/config/autoplacement_property.md
+++ b/docs/api/diagram_editor/editor/config/autoplacement_property.md
@@ -1,5 +1,5 @@
 ---
-sidebar_label: autoplacement 
+sidebar_label: autoplacement
 title: autoplacement Property of Editor
 description: You can learn about the autoplacement property of editor in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Diagram.
 ---
@@ -116,7 +116,7 @@ Shapes are arranged on imaginary circles relative to the central shape, i.e. the
 
 ![](/img/edges_radial.png)
 
-**Change log**:  
+**Change log**:
 
 - The `itemPadding` and `levelPadding` parameters are added in v6.1.3
 - The `placeMode` parameter is added in v5.0

--- a/docs/api/diagram_editor/editor/config/defaults_property.md
+++ b/docs/api/diagram_editor/editor/config/defaults_property.md
@@ -63,7 +63,7 @@ After defining the default settings for the shape/line of separate types, you ca
 
 **Change log**: The ability to set the default configuration for lines was added in v4.2
 
-**Related articles**:  
+**Related articles**:
 
 - [Setting the default configuration of a shape](guides/diagram/configuration.md#setting-the-default-configuration-of-a-shape)
 - [Setting the preview of shapes](guides/diagram_editor/shapebar.md#setting-the-preview-of-shapes)

--- a/docs/api/diagram_editor/editor/config/hotkeys_property.md
+++ b/docs/api/diagram_editor/editor/config/hotkeys_property.md
@@ -1,5 +1,5 @@
 ---
-sidebar_label: hotkeys 
+sidebar_label: hotkeys
 title: hotkeys Property of Editor
 description: You can learn about the hotkeys property of editor in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Diagram.
 ---
@@ -16,7 +16,7 @@ You can completely disable all hotkeys, disable specific combinations, or overri
 Please note that enabling or disabling default hotkeys will also affect their visibility as tooltips or labels in the editor's Toolbar.
 :::
 
-### Usage 
+### Usage
 
 ~~~jsx
 hotkeys?:

--- a/docs/api/diagram_editor/editor/config/lineconfig_property.md
+++ b/docs/api/diagram_editor/editor/config/lineconfig_property.md
@@ -8,7 +8,7 @@ description: You can learn about the lineConfig property in the documentation of
 
 ### Description
 
-@short: Optional. An object with default configuration for the connector lines 
+@short: Optional. An object with default configuration for the connector lines
 
 :::info
 The `lineType`, `lineDirection` and `arrowsHidden` settings will be applied to the new connector lines which are added via the editor.

--- a/docs/api/diagram_editor/editor/config/magnetic_property.md
+++ b/docs/api/diagram_editor/editor/config/magnetic_property.md
@@ -31,7 +31,7 @@ magnetic?: {
 ### Default config
 
 ~~~jsx
-magnetic: true 
+magnetic: true
 ~~~
 
 The magnetic mode is enabled with the following configuration:

--- a/docs/api/diagram_editor/editor/config/shapetoolbar_property.md
+++ b/docs/api/diagram_editor/editor/config/shapetoolbar_property.md
@@ -1,5 +1,5 @@
 ---
-sidebar_label: shapeToolbar 
+sidebar_label: shapeToolbar
 title: shapeToolbar Property of Editor
 description: You can learn about the shapeToolbar property of editor in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Diagram.
 ---
@@ -26,7 +26,7 @@ As an array, the `shapeToolbar` property can include:
     - in the org chart mode: `"add"` | `"horizontal"` | `"vertical"` | `"remove"`
     - in the mindmap mode: `"add"` | `"addLeft"` | `"addRight"` | `"remove"`
 - a set of icon objects. Each icon object can have the following properties:
-    - `id: string` -  (required) the id of an icon. Note, that the usage of the default names of the toolbar controls as ids of new controls is prohibited
+    - `id: string` -  (required) the id of an icon. Note that using the default names of the toolbar controls as ids of new controls is prohibited
     - `content: string` - (required) the content of the icon. It can contain an HTML element with the name of the icon class
     - `check: function` - (optional) checks whether the icon should be applied to the shape. The function takes a shape object and returns *true*, if the icon will be rendered for this shape
     - `css: function` - (optional) the function which returns the name(s) of CSS class(es) that should be applied to the shape
@@ -65,7 +65,7 @@ const editor = new dhx.DiagramEditor("editor_container", {
 
 ### Redefining the default toolbar for certain items
 
-You may need to provide some items with a specific toolbar controls, while other items will have the default one. In this case you should enable the default toolbar by specifying the *true* value in the `shapeToolbar` array and add the necessary icon object that will contain a check function defining what shape the icon will be applied for.  
+You may need to provide some items with a specific toolbar controls, while other items will have the default one. In this case you should enable the default toolbar by specifying the *true* value in the `shapeToolbar` array and add the necessary icon object that will contain a check function defining what shape the icon will be applied for.
 
 ~~~jsx title="Setting the download icon for items with the start type"
 const editor = new dhx.DiagramEditor("editor_container", {

--- a/docs/api/diagram_editor/editor/config/view_property.md
+++ b/docs/api/diagram_editor/editor/config/view_property.md
@@ -51,7 +51,7 @@ const editor = new dhx.DiagramEditor("editor_container", {
         },
         editbar: false
     }
-    // other configurations 
+    // other configurations
 });
 ~~~
 

--- a/docs/api/diagram_editor/editor/events/aftergroupmove_event.md
+++ b/docs/api/diagram_editor/editor/events/aftergroupmove_event.md
@@ -18,7 +18,7 @@ The event fires just for the target element despite the number of selected eleme
 
 ~~~jsx
 "afterGroupMove": ({
-    id: string | number, 
+    id: string | number,
     batch: (string | number)[],
     coords: object,
     event: PointerEvent
@@ -52,7 +52,7 @@ editor.parse(data);
 editor.events.on("afterGroupMove", ({ id, coords }) => {
     console.log(`
         Group ${id} is at the position:
-            x: ${coords.x} 
+            x: ${coords.x}
             y: ${coords.y}
     `);
 });

--- a/docs/api/diagram_editor/editor/events/afteritemcatch_event.md
+++ b/docs/api/diagram_editor/editor/events/afteritemcatch_event.md
@@ -18,7 +18,7 @@ The event works only in the **org chart** and `mindmap` modes of Diagram, the `i
 
 ~~~jsx
 "afterItemCatch": ({
-    id: string | number, 
+    id: string | number,
     targetId: string | number,
     batch: (string | number)[],
     event: PointerEvent
@@ -31,7 +31,7 @@ The callback of the event is called with an object with the following parameters
 
   - `id` - the id of the moved item
   - `targetId` - the id of the target item
-  - `batch` - an array of moved elements' ids 
+  - `batch` - an array of moved elements' ids
   - `event` - an event object
 
 ### Example

--- a/docs/api/diagram_editor/editor/events/afteritemmove_event.md
+++ b/docs/api/diagram_editor/editor/events/afteritemmove_event.md
@@ -20,7 +20,7 @@ The event fires just for the target element despite the number of selected eleme
 
 ~~~jsx
 "afterItemMove": ({
-    id: string | number, 
+    id: string | number,
     batch: (string | number)[],
     coords: object,
     event: PointerEvent
@@ -53,8 +53,8 @@ editor.parse(data);
 // attaching a handler to the event
 editor.events.on("afterItemMove", ({ id, coords }) => {
     console.log(`
-        Item ${id} is at the position: 
-            x: ${coords.x} 
+        Item ${id} is at the position:
+            x: ${coords.x}
             y: ${coords.y}
     `);
 });

--- a/docs/api/diagram_editor/editor/events/afteritemresize_event.md
+++ b/docs/api/diagram_editor/editor/events/afteritemresize_event.md
@@ -14,7 +14,7 @@ description: You can learn about the afterItemResize event of editor in the docu
 
 ~~~jsx
 "afterItemResize": ({
-    id: string | number, 
+    id: string | number,
     width: number,
     height: number,
     x: number,
@@ -53,8 +53,8 @@ editor.parse(data);
 // attaching a handler to the event
 editor.events.on("afterItemResize", ({ id, width, height }) => {
     console.log(`
-        The item ${id} has been resized: 
-            width: ${width} 
+        The item ${id} has been resized:
+            width: ${width}
             height: ${height}
     `);
 });

--- a/docs/api/diagram_editor/editor/events/afterlinetitlemove_event.md
+++ b/docs/api/diagram_editor/editor/events/afterlinetitlemove_event.md
@@ -14,9 +14,9 @@ description: You can learn about the afterLineTitleMove event of editor in the d
 
 ~~~jsx
 "afterLineTitleMove": ({
-    event: PointerEvent, 
-    lineId: string | number, 
-    titleId: string | number, 
+    event: PointerEvent,
+    lineId: string | number,
+    titleId: string | number,
     coords: object
 }) => void;
 ~~~

--- a/docs/api/diagram_editor/editor/events/aftershapeiconclick_event.md
+++ b/docs/api/diagram_editor/editor/events/aftershapeiconclick_event.md
@@ -14,7 +14,7 @@ description: You can learn about the afterShapeIconClick event of editor in the 
 
 ~~~jsx
 "afterShapeIconClick": (
-    iconId: string, 
+    iconId: string,
     shape: object
 ) => void;
 ~~~

--- a/docs/api/diagram_editor/editor/events/aftershapemove_event.md
+++ b/docs/api/diagram_editor/editor/events/aftershapemove_event.md
@@ -18,7 +18,7 @@ The event fires just for the target element despite the number of selected eleme
 
 ~~~jsx
 "afterShapeMove": ({
-    id: string | number, 
+    id: string | number,
     batch: (string | number)[],
     coords: object,
     event: PointerEvent,
@@ -52,7 +52,7 @@ editor.parse(data);
 editor.events.on("afterShapeMove", ({ id, coords }) => {
     console.log(`
         Shape ${id} is at the position:
-            x: ${coords.x} 
+            x: ${coords.x}
             y: ${coords.y}
     `);
 });

--- a/docs/api/diagram_editor/editor/events/beforegroupmove_event.md
+++ b/docs/api/diagram_editor/editor/events/beforegroupmove_event.md
@@ -18,10 +18,10 @@ The event fires just for the target element despite the number of selected eleme
 
 ~~~jsx
 "beforeGroupMove": ({
-    id: string | number, 
+    id: string | number,
     batch: (string | number)[],
     coords: object,
-    event: PointerEvent 
+    event: PointerEvent
 }) => boolean | void;
 ~~~
 
@@ -35,7 +35,7 @@ The callback of the event is called with an object with the following parameters
     - `x` - the horizontal position of the group/swimlane, moving from left to right
     - `y` - the vertical position of the group/swimlane, moving from top to bottom
   - `event` - an event object
-  
+
 ### Returns
 
 The callback returns `false` to prevent the group or swimlane from being moved; otherwise, `true`
@@ -56,7 +56,7 @@ editor.parse(data);
 editor.events.on("beforeGroupMove", ({ id, coords }) => {
     console.log(`
         Group ${id} is at the position:
-            x: ${coords.x} 
+            x: ${coords.x}
             y: ${coords.y}
     `);
     return true;

--- a/docs/api/diagram_editor/editor/events/beforeitemcatch_event.md
+++ b/docs/api/diagram_editor/editor/events/beforeitemcatch_event.md
@@ -18,7 +18,7 @@ The event works only in the **org chart** and `mindmap` modes of Diagram, the `i
 
 ~~~jsx
 "beforeItemCatch": ({
-    id: string | number, 
+    id: string | number,
     targetId: string | number,
     batch: (string | number)[],
     event: PointerEvent
@@ -31,7 +31,7 @@ The callback of the event is called with an object with the following parameters
 
   - `id` - the id of the moved item
   - `targetId` - the id of the target item
-  - `batch` - an array of moved elements' ids 
+  - `batch` - an array of moved elements' ids
   - `event` - an event object
 
 ### Returns
@@ -67,7 +67,7 @@ editor.events.on("beforeItemCatch", ({ id, targetId }) => {
 });
 ~~~
 
-**Change log**:  
+**Change log**:
 
 - The `batch` parameter was added in the v6.0
 - The callback function takes an object as a parameter since v6.0

--- a/docs/api/diagram_editor/editor/events/beforeitemmove_event.md
+++ b/docs/api/diagram_editor/editor/events/beforeitemmove_event.md
@@ -20,10 +20,10 @@ The event fires just for the target element despite the number of selected eleme
 
 ~~~jsx
 "beforeItemMove": ({
-    id: string | number, 
+    id: string | number,
     batch: (string | number)[],
     coords: object,
-    event: PointerEvent, 
+    event: PointerEvent,
 }) => boolean | void;
 ~~~
 
@@ -57,8 +57,8 @@ editor.parse(data);
 // attaching a handler to the event
 editor.events.on("beforeItemMove", ({ id, coords }) => {
     console.log(`
-        Item ${id} is at the position: 
-            x: ${coords.x} 
+        Item ${id} is at the position:
+            x: ${coords.x}
             y: ${coords.y}
     `);
     return true;

--- a/docs/api/diagram_editor/editor/events/beforeitemresize_event.md
+++ b/docs/api/diagram_editor/editor/events/beforeitemresize_event.md
@@ -14,7 +14,7 @@ description: You can learn about the beforeItemResize event of editor in the doc
 
 ~~~jsx
 "beforeItemResize": ({
-    id: string | number, 
+    id: string | number,
     width: number,
     height: number,
     x: number,

--- a/docs/api/diagram_editor/editor/events/beforelinetitlemove_event.md
+++ b/docs/api/diagram_editor/editor/events/beforelinetitlemove_event.md
@@ -14,9 +14,9 @@ description: You can learn about the beforeLineTitleMove event of editor in the 
 
 ~~~jsx
 "beforeLineTitleMove": ({
-    event: PointerEvent, 
-    lineId: string | number, 
-    titleId: string | number, 
+    event: PointerEvent,
+    lineId: string | number,
+    titleId: string | number,
     coords: obj
 }) => boolean | void;
 ~~~

--- a/docs/api/diagram_editor/editor/events/beforeshapeiconclick_event.md
+++ b/docs/api/diagram_editor/editor/events/beforeshapeiconclick_event.md
@@ -14,7 +14,7 @@ description: You can learn about the beforeShapeIconClick event of editor in the
 
 ~~~jsx
 "beforeShapeIconClick": (
-    iconId: string, 
+    iconId: string,
     shape: object
 ) => boolean | void;
 ~~~

--- a/docs/api/diagram_editor/editor/events/beforeshapemove_event.md
+++ b/docs/api/diagram_editor/editor/events/beforeshapemove_event.md
@@ -18,7 +18,7 @@ The event fires just for the target element despite the number of selected eleme
 
 ~~~jsx
 "beforeShapeMove": ({
-    id: string | number, 
+    id: string | number,
     batch: (string | number)[],
     coords: object,
     event: PointerEvent

--- a/docs/api/diagram_editor/editor/events/groupmoveend_event.md
+++ b/docs/api/diagram_editor/editor/events/groupmoveend_event.md
@@ -18,7 +18,7 @@ The event fires just for the target element despite the number of selected eleme
 
 ~~~jsx
 "groupMoveEnd": ({
-    id: string | number, 
+    id: string | number,
     batch: (string | number)[],
     coords: object,
     event: PointerEvent,
@@ -51,8 +51,8 @@ editor.parse(data);
 // attaching a handler to the event
 editor.events.on("groupMoveEnd", ({ id, coords }) => {
     console.log(`
-        Group ${id} is at the position: 
-            x: ${coords.x} 
+        Group ${id} is at the position:
+            x: ${coords.x}
             y: ${coords.y}
     `);
 });

--- a/docs/api/diagram_editor/editor/events/itemmoveend_event.md
+++ b/docs/api/diagram_editor/editor/events/itemmoveend_event.md
@@ -20,7 +20,7 @@ The event fires just for the target element despite the number of selected eleme
 
 ~~~jsx
 "itemMoveEnd": ({
-    id: string | number, 
+    id: string | number,
     batch: (string | number)[],
     coords: object,
     event: PointerEvent
@@ -49,8 +49,8 @@ editor.parse(data);
 // attaching a handler to the event
 editor.events.on("itemMoveEnd", ({ id, coords }) => {
     console.log(`
-        Item ${id} is at the position: 
-            x: ${coords.x} 
+        Item ${id} is at the position:
+            x: ${coords.x}
             y: ${coords.y}
     `);
 });

--- a/docs/api/diagram_editor/editor/events/itemresizeend_event.md
+++ b/docs/api/diagram_editor/editor/events/itemresizeend_event.md
@@ -54,8 +54,8 @@ editor.parse(data);
 // attaching a handler to the event
 editor.events.on("itemResizeEnd", ({ id, width, height }) => {
     console.log(`
-        The item ${id} finished resizing: 
-            the final width: ${width} 
+        The item ${id} finished resizing:
+            the final width: ${width}
             the final height: ${height}
     `);
     // Here you can save the new dimensions of the item on the server

--- a/docs/api/diagram_editor/editor/events/itemtarget_event.md
+++ b/docs/api/diagram_editor/editor/events/itemtarget_event.md
@@ -20,7 +20,7 @@ The event doesn't work with the *parent item of a moved item* and with a *moved 
 
 ~~~jsx
 "itemTarget": ({
-    id: string | number, 
+    id: string | number,
     targetId: string | number,
     batch: (string | number)[],
     event: PointerEvent

--- a/docs/api/diagram_editor/editor/events/linetitlemoveend_event.md
+++ b/docs/api/diagram_editor/editor/events/linetitlemoveend_event.md
@@ -14,9 +14,9 @@ description: You can learn about the lineTitleMoveEnd event of editor in the doc
 
 ~~~jsx
 "lineTitleMoveEnd": ({
-    event: PointerEvent, 
-    lineId: string | number, 
-    titleId: string | number, 
+    event: PointerEvent,
+    lineId: string | number,
+    titleId: string | number,
     coords: obj
 }) => void;
 ~~~

--- a/docs/api/diagram_editor/editor/events/shapemoveend_event.md
+++ b/docs/api/diagram_editor/editor/events/shapemoveend_event.md
@@ -18,7 +18,7 @@ The event fires just for the target element despite the number of selected eleme
 
 ~~~jsx
 "shapeMoveEnd": ({
-    id: string | number, 
+    id: string | number,
     batch: (string | number)[],
     coords: object,
     event: PointerEvent
@@ -52,7 +52,7 @@ editor.parse(data);
 editor.events.on("shapeMoveEnd", ({ id, coords }) => {
     console.log(`
         Shape ${id} is at the position:
-            x: ${coords.x} 
+            x: ${coords.x}
             y: ${coords.y}
     `);
 });

--- a/docs/api/diagram_editor/editor/methods/destructor_method.md
+++ b/docs/api/diagram_editor/editor/methods/destructor_method.md
@@ -1,5 +1,5 @@
 ---
-sidebar_label: destructor() 
+sidebar_label: destructor()
 title: destructor Method of Editor
 description: You can learn about the destructor method in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Diagram.
 ---

--- a/docs/api/diagram_editor/editor/methods/parse_method.md
+++ b/docs/api/diagram_editor/editor/methods/parse_method.md
@@ -43,7 +43,7 @@ const data = [
         "type": "rectangle",
         "text": "Shape 2"
     },
- 
+
     // connector line
     {
         "id": "ab",
@@ -53,7 +53,7 @@ const data = [
     },
 ];
 
-const editor = new dhx.DiagramEditor("editor_container"); 
+const editor = new dhx.DiagramEditor("editor_container");
 editor.parse(data);
 ~~~
 

--- a/docs/api/diagram_editor/historymanager/api_overview.md
+++ b/docs/api/diagram_editor/historymanager/api_overview.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: History manager API overview
-title: History manager API overview 
+title: History manager API overview
 description: You can check a History manager overview in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Diagram.
 ---
 
@@ -9,7 +9,7 @@ description: You can check a History manager overview in the documentation of th
 A set of APIs that you can use for managing the history of actions in the Diagram Editor. Use the `history` keyword to access the History manager via the `editor` object:
 
 ~~~jsx {5}
-const editor = new dhx.DiagramEditor("editor_container", { 
+const editor = new dhx.DiagramEditor("editor_container", {
     type: "default" // only default
 });
 // ...

--- a/docs/api/diagram_editor/historymanager/config/savedelay_property.md
+++ b/docs/api/diagram_editor/historymanager/config/savedelay_property.md
@@ -25,7 +25,7 @@ saveDelay: 500
 ### Example
 
 ~~~jsx {5}
-const editor = new dhx.DiagramEditor("editor_container", { 
+const editor = new dhx.DiagramEditor("editor_container", {
     type: "default"
 });
 

--- a/docs/api/diagram_editor/historymanager/methods/add_method.md
+++ b/docs/api/diagram_editor/historymanager/methods/add_method.md
@@ -27,7 +27,7 @@ add(newState: array): void;
 ### Example
 
 ~~~jsx {5-9}
-const editor = new dhx.DiagramEditor("editor_container", { 
+const editor = new dhx.DiagramEditor("editor_container", {
     type: "default"
 });
 // ...

--- a/docs/api/diagram_editor/historymanager/methods/disable_method.md
+++ b/docs/api/diagram_editor/historymanager/methods/disable_method.md
@@ -19,7 +19,7 @@ disable(): void;
 ### Example
 
 ~~~jsx {5}
-const editor = new dhx.DiagramEditor("editor_container", { 
+const editor = new dhx.DiagramEditor("editor_container", {
     type: "default"
 });
 // ...

--- a/docs/api/diagram_editor/historymanager/methods/enable_method.md
+++ b/docs/api/diagram_editor/historymanager/methods/enable_method.md
@@ -19,7 +19,7 @@ enable(): void;
 ### Example
 
 ~~~jsx {5}
-const editor = new dhx.DiagramEditor("editor_container", { 
+const editor = new dhx.DiagramEditor("editor_container", {
     type: "default"
 });
 // ...

--- a/docs/api/diagram_editor/historymanager/methods/isredo_method.md
+++ b/docs/api/diagram_editor/historymanager/methods/isredo_method.md
@@ -19,7 +19,7 @@ isRedo(): boolean;
 ### Example
 
 ~~~jsx {5}
-const editor = new dhx.DiagramEditor("editor_container", { 
+const editor = new dhx.DiagramEditor("editor_container", {
     type: "default"
 });
 ...

--- a/docs/api/diagram_editor/historymanager/methods/isundo_method.md
+++ b/docs/api/diagram_editor/historymanager/methods/isundo_method.md
@@ -19,7 +19,7 @@ isUndo(): boolean;
 ### Example
 
 ~~~jsx {5}
-const editor = new dhx.DiagramEditor("editor_container", { 
+const editor = new dhx.DiagramEditor("editor_container", {
     type: "default"
 });
 // ...

--- a/docs/api/diagram_editor/historymanager/methods/redo_method.md
+++ b/docs/api/diagram_editor/historymanager/methods/redo_method.md
@@ -19,7 +19,7 @@ redo(): void;
 ### Example
 
 ~~~jsx {5}
-const editor = new dhx.DiagramEditor("editor_container", { 
+const editor = new dhx.DiagramEditor("editor_container", {
     type: "default"
 });
 // ...

--- a/docs/api/diagram_editor/historymanager/methods/reset_method.md
+++ b/docs/api/diagram_editor/historymanager/methods/reset_method.md
@@ -19,7 +19,7 @@ reset(): void;
 ### Example
 
 ~~~jsx {5}
-const editor = new dhx.DiagramEditor("editor_container", { 
+const editor = new dhx.DiagramEditor("editor_container", {
     type: "default"
 });
 // ...

--- a/docs/api/diagram_editor/historymanager/methods/undo_method.md
+++ b/docs/api/diagram_editor/historymanager/methods/undo_method.md
@@ -18,12 +18,12 @@ undo(first?: boolean): void;
 
 ### Parameters
 
-- `first` - (optional) *true* to revert all the history of changes 
+- `first` - (optional) *true* to revert all the history of changes
 
 ### Example
 
 ~~~jsx {5}
-const editor = new dhx.DiagramEditor("editor_container", { 
+const editor = new dhx.DiagramEditor("editor_container", {
     type: "default"
 });
 // ...

--- a/docs/api/diagram_editor/shapebar/api_overview.md
+++ b/docs/api/diagram_editor/shapebar/api_overview.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Shapebar API overview
-title: Shapebar API overview 
+title: Shapebar API overview
 description: You can check a Shapebar overview in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Diagram.
 ---
 
@@ -36,7 +36,7 @@ const editor = new dhx.DiagramEditor("editor_container", {
             },
             sections: {
                 "Swimlane": [{ swimlane: true }],
-                "Groups": [{ group: true }],   
+                "Groups": [{ group: true }],
                 "Flowchart shapes": [{ flowShapes: true }],
                 "Org shapes, text, topic": [{ org: true }, "text", "topic"]
             }

--- a/docs/api/diagram_editor/shapebar/config/preview_property.md
+++ b/docs/api/diagram_editor/shapebar/config/preview_property.md
@@ -60,12 +60,12 @@ The values of the `gap` and `scale` properties can be redefined for a separate s
 const defaults = {
     rectangle: {
         preview: {
-            scale: 0.72, 
+            scale: 0.72,
             gap: 8
         }
     }
 }
- 
+
 const editor = new dhx.DiagramEditor("editor_container", {
     type: "default",
     view: {
@@ -76,7 +76,7 @@ const editor = new dhx.DiagramEditor("editor_container", {
             }
         }
     },
-    defaults        
+    defaults
 });
 ~~~
 

--- a/docs/api/diagram_editor/shapebar/config/sections_property.md
+++ b/docs/api/diagram_editor/shapebar/config/sections_property.md
@@ -46,7 +46,7 @@ const editor = new dhx.DiagramEditor("editor_container", {
         shapebar: {
             sections: {
                 "Swimlane": [{ swimlane: true }],
-                "Groups": [{ group: true }],   
+                "Groups": [{ group: true }],
                 "Flowchart shapes": [{ flowShapes: true }],
                 "Org shapes, text, topic": [{ org: true }, "text", "topic"]
             }

--- a/docs/api/diagram_editor/shapebar/config/show_property.md
+++ b/docs/api/diagram_editor/shapebar/config/show_property.md
@@ -19,7 +19,7 @@ show?: boolean;
 ### Default config
 
 ~~~jsx
-show: true 
+show: true
 ~~~
 
 ### Example

--- a/docs/api/diagram_editor/toolbar/api_overview.md
+++ b/docs/api/diagram_editor/toolbar/api_overview.md
@@ -1,12 +1,12 @@
 ---
 sidebar_label: Toolbar API overview
-title: Toolbar API overview 
+title: Toolbar API overview
 description: You can check a Toolbar overview in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Diagram.
 ---
 
 # Toolbar API overview
 
-[Toolbar](guides/diagram_editor/toolbar.md) is a part of the Diagram Editor that helps users to control the editing process. Use the `toolbar` property of the [`view`](api/diagram_editor/editor/config/view_property.md) configuration object to show, hide and configure the Toolbar. There are two ways of initialization you can choose from:
+[Toolbar](guides/diagram_editor/toolbar.md) is a part of the Diagram Editor that helps users control the editing process. Use the `toolbar` property of the [`view`](api/diagram_editor/editor/config/view_property.md) configuration object to show, hide and configure the Toolbar. There are two ways of initialization you can choose from:
 
 - creating the default Toolbar by using the `toolbar:true` setting:
 

--- a/docs/api/diagram_editor/toolbar/config/items_property.md
+++ b/docs/api/diagram_editor/toolbar/config/items_property.md
@@ -31,7 +31,7 @@ The full list of service elements you can see [here](guides/diagram_editor/toolb
 The `items` property allows you to specify [**Service elements**](guides/diagram_editor/toolbar.md#service-elements) and [**Base elements**](guides/diagram_editor/toolbar.md#base-elements) as an array of objects:
 
 ~~~jsx
-items: [ 
+items: [
     {
         type: string,
         id?: string,
@@ -44,7 +44,7 @@ items: [
         items?: (string | object)[],
         checkIcon?: (editor: object) => string,
         handler?: (editor: object, event: Event) => void
-    }, {...} 
+    }, {...}
 ];
 ~~~
 
@@ -82,8 +82,8 @@ const editor = new dhx.DiagramEditor("editor_container", {
             css: "custom_css",
             navigationType: "pointer",
             items: [
-                "file", 
-                "spacer", 
+                "file",
+                "spacer",
                 "scale"
             ]
         }

--- a/docs/api/diagram_editor/toolbar/methods/overview.md
+++ b/docs/api/diagram_editor/toolbar/methods/overview.md
@@ -7,7 +7,7 @@ description: You can learn about Toolbar methods in the documentation of the DHT
 # Toolbar methods overview
 
 :::info
-Use the [`parse()`](api/diagram_editor/toolbar/methods/parse_method.md) method to manipulate data in Toolbar. 
+Use the [`parse()`](api/diagram_editor/toolbar/methods/parse_method.md) method to manipulate data in Toolbar.
 :::
 
 You can use the following [`Toolbar`](https://docs.dhtmlx.com/suite/category/toolbar-methods/) methods of [**Suite**](https://docs.dhtmlx.com/suite/):

--- a/docs/api/diagram_editor/view/api_overview.md
+++ b/docs/api/diagram_editor/view/api_overview.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: View API overview
-title: View API overview 
+title: View API overview
 description: You can check a View overview in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Diagram.
 ---
 

--- a/docs/api/diagram_editor/view/methods/hide_method.md
+++ b/docs/api/diagram_editor/view/methods/hide_method.md
@@ -34,7 +34,7 @@ const editor = new dhx.DiagramEditor("editor_container", {
 });
 
 // hides the Shapebar view
-editor.view.hide("shapebar"); 
+editor.view.hide("shapebar");
 
 // hides Shapebar, Editbar, and Toolbar
 editor.view.hide();

--- a/docs/api/diagram_editor/view/methods/show_method.md
+++ b/docs/api/diagram_editor/view/methods/show_method.md
@@ -33,10 +33,10 @@ const editor = new dhx.DiagramEditor("editor_container", {
     type: "default"
 });
 
-// shows the Shapebar view 
-editor.view.show("shapebar"); 
+// shows the Shapebar view
+editor.view.show("shapebar");
 
-// shows Shapebar, Editbar, and Toolbar 
+// shows Shapebar, Editbar, and Toolbar
 editor.view.show();
 ~~~
 

--- a/docs/api/export/index.md
+++ b/docs/api/export/index.md
@@ -7,6 +7,7 @@ description: You can have an overview of diagram export methods in the documenta
 # Export methods overview
 
 The API methods of the `diagram.export` object allow you to export data from the Diagram or Diagram Editor.
+
 ## Methods
 
 | Name                         | Description                         |

--- a/docs/api/export/pdf_method.md
+++ b/docs/api/export/pdf_method.md
@@ -57,7 +57,7 @@ A promise of data export
 
 ### Example
 
-~~~jsx 
+~~~jsx
 const diagram = new dhx.Diagram("diagram_container", {
     // config options
 });
@@ -82,7 +82,7 @@ diagram.export.pdf({
 ### Details
 
 :::info
-It is necessary to set sufficient margin for correct display of `headerTemplate`/`footerTemplate`.
+Set a sufficient margin for correct display of `headerTemplate`/`footerTemplate`.
 :::
 
 ## List of formats
@@ -103,7 +103,7 @@ It is necessary to set sufficient margin for correct display of `headerTemplate`
 
 **Related articles**:  [Exporting Diagram](guides/data_export.md)
 
-**Related samples**: 
+**Related samples**:
 
 - [Diagram. Export. Export diagram](https://snippet.dhtmlx.com/ybpmz0zk)
 - [Diagram. Export. Bottom-left watermark](https://snippet.dhtmlx.com/d56spdsc)

--- a/docs/api/export/png_method.md
+++ b/docs/api/export/png_method.md
@@ -4,7 +4,7 @@ title: png Method
 description: You can learn about the png method in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Diagram.
 ---
 
-# png
+# png()
 
 ### Description
 
@@ -34,7 +34,7 @@ A promise of data export
 
 ### Example
 
-~~~jsx 
+~~~jsx
 const diagram = new dhx.Diagram("diagram_container", {
     // config options
 });
@@ -57,7 +57,7 @@ diagram.export.png({
 
 **Related articles**:  [Exporting Diagram](guides/data_export.md)
 
-**Related samples**: 
+**Related samples**:
 
 - [Diagram. Export. Export diagram](https://snippet.dhtmlx.com/ybpmz0zk)
 - [Diagram. Export. Bottom-left watermark](https://snippet.dhtmlx.com/d56spdsc)

--- a/docs/api/inline_editor/aftereditorclose_event.md
+++ b/docs/api/inline_editor/aftereditorclose_event.md
@@ -14,8 +14,8 @@ description: You can learn about the afterEditorClose event in the documentation
 
 ~~~jsx
 afterEditorClose: (
-    id: string | number, 
-    key: string, 
+    id: string | number,
+    key: string,
     subId?: string
 ) => void;
 ~~~

--- a/docs/api/inline_editor/aftereditorediting_event.md
+++ b/docs/api/inline_editor/aftereditorediting_event.md
@@ -8,15 +8,15 @@ description: You can learn about the afterEditorEditing event in the documentati
 
 ### Description
 
-@short: Fires after the text value of an item is edited via the inline editor  
+@short: Fires after the text value of an item is edited via the inline editor
 
 ### Usage
 
 ~~~jsx
 afterEditorEditing: (
-    value: string, 
-    id: string | number, 
-    key: string, 
+    value: string,
+    id: string | number,
+    key: string,
     subId?: string
 ) => void;
 ~~~

--- a/docs/api/inline_editor/aftereditoropen_event.md
+++ b/docs/api/inline_editor/aftereditoropen_event.md
@@ -14,8 +14,8 @@ description: You can learn about the afterEditorOpen event in the documentation 
 
 ~~~jsx
 afterEditorOpen: (
-    id: string | number, 
-    key: string, 
+    id: string | number,
+    key: string,
     subId?: string
 ) => void;
 ~~~

--- a/docs/api/inline_editor/beforeeditorclose_event.md
+++ b/docs/api/inline_editor/beforeeditorclose_event.md
@@ -14,8 +14,8 @@ description: You can learn about the beforeEditorClose event in the documentatio
 
 ~~~jsx
 beforeEditorClose: (
-    id: string | number, 
-    key: string, 
+    id: string | number,
+    key: string,
     subId?: string
 ) => boolean | void;
 ~~~

--- a/docs/api/inline_editor/beforeeditorediting_event.md
+++ b/docs/api/inline_editor/beforeeditorediting_event.md
@@ -14,10 +14,10 @@ description: You can learn about the beforeEditorEditing event in the documentat
 
 ~~~jsx
 beforeEditorEditing: (
-    value: string, 
-    currentValue: string, 
-    id: string | number, 
-    key: string, 
+    value: string,
+    currentValue: string,
+    id: string | number,
+    key: string,
     subId?: string
 ) => boolean | void;
 ~~~

--- a/docs/api/inline_editor/beforeeditoropen_event.md
+++ b/docs/api/inline_editor/beforeeditoropen_event.md
@@ -14,8 +14,8 @@ description: You can learn about the beforeEditorOpen event in the documentation
 
 ~~~jsx
 beforeEditorOpen: (
-    id: string | number, 
-    key: string, 
+    id: string | number,
+    key: string,
     subId?: string
 ) => boolean | void;
 ~~~

--- a/docs/api/inline_editor/index.md
+++ b/docs/api/inline_editor/index.md
@@ -6,7 +6,7 @@ description: You can have an overview of inline editor in the documentation of t
 
 # InlineEditor events overview
 
-The API set for controlling the process of editing the text of items by double-click on the text. The API can be used both in the diagram and in the editor.
+A set of APIs for controlling the process of editing the text of items by double-clicking on the text. The API can be used both in the diagram and in the editor.
 
 ## Events
 

--- a/docs/api/selection/add_method.md
+++ b/docs/api/selection/add_method.md
@@ -33,14 +33,14 @@ The method takes as an argument an object with the following parameters:
 The method returns:
 
 - `true` if the element hadn't been in the selection list and was successfully added into it
-- `false` if the element wasn't added into the selection list by some reason, e.g. an element had already been added to the selection list
+- `false` if the element wasn't added into the selection list for some reason, e.g. an element had already been added to the selection list
 
 ### Example
 
 ~~~jsx {8,11-12,15-16}
 // a diagram must be created with the "select:true" option
-const diagram = new dhx.Diagram("diagram_container", { 
-    select: true 
+const diagram = new dhx.Diagram("diagram_container", {
+    select: true
 });
 // loading data
 diagram.data.parse(data);
@@ -49,17 +49,17 @@ diagram.selection.add({ id: "1" }); // -> returns true if the item has been sele
 console.log(diagram.selection.getIds()); // -> ["1"]
 
 // adds the item with the id:"2" to the already selected items
-diagram.selection.add({ id: "2", join: true }); 
+diagram.selection.add({ id: "2", join: true });
 console.log(diagram.selection.getIds()); // -> ["1", "2"]
 
 // removes the previously selected items and adds the item with the id:"3"
-diagram.selection.add({ id: "3" }); 
+diagram.selection.add({ id: "3" });
 console.log(diagram.selection.getIds()); // -> ["3"]
 ~~~
 
 **Change log**: Updated in v6.0
 
-**Related articles**:  
+**Related articles**:
 
 - [diagram.config.select](api/diagram/select_property.md)
 - [Selecting items](guides/manipulating_items.md#selecting-items)

--- a/docs/api/selection/afterselect_event.md
+++ b/docs/api/selection/afterselect_event.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: afterSelect
 title: afterSelect Event of Selection
-description: You can learn about the afterSelect event in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Diagram.xt
+description: You can learn about the afterSelect event in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Diagram.
 ---
 
 # afterSelect
@@ -14,7 +14,7 @@ description: You can learn about the afterSelect event in the documentation of t
 
 ~~~jsx
 "afterSelect": ({
-    id: string | number, 
+    id: string | number,
     join: boolean,
     batch: (string | number)[]
 }) => void;
@@ -32,7 +32,7 @@ The callback of the event is called with an object with the following parameters
 
 ~~~jsx {9-12}
 // initializing Diagram
-const diagram = new dhx.Diagram("diagram_container", {  
+const diagram = new dhx.Diagram("diagram_container", {
     select: true,
     // other config options
 });
@@ -49,7 +49,7 @@ Here's an example of attaching an event handler to the event for the Diagram Edi
 
 ~~~jsx {8-11}
 // initializing Diagram editor
-const editor = new dhx.DiagramEditor("editor_container", {  
+const editor = new dhx.DiagramEditor("editor_container", {
     // config options
 });
 // loading data into the editor
@@ -63,7 +63,7 @@ editor.diagram.events.on("afterSelect", ({ id }) => {
 
 **Change log**: Updated in v6.0
 
-**Related articles**:  
+**Related articles**:
 
 - [diagram.config.select](api/diagram/select_property.md)
 - [Selecting items](guides/manipulating_items.md#selecting-items)

--- a/docs/api/selection/afterunselect_event.md
+++ b/docs/api/selection/afterunselect_event.md
@@ -14,7 +14,7 @@ description: You can learn about the afterUnSelect event in the documentation of
 
 ~~~jsx
 "afterUnSelect": ({
-    id: string | number, 
+    id: string | number,
     batch: (string | number)[]
 }) => void;
 ~~~
@@ -23,16 +23,16 @@ description: You can learn about the afterUnSelect event in the documentation of
 
 The callback of the event is called with an object with the following parameters:
 
-- `id` - the id of the unselected item 
+- `id` - the id of the unselected item
 - `batch` - the list of unselected items
 
 ### Example
 
 ~~~jsx {9-12}
 // initializing Diagram
-const diagram = new dhx.Diagram("diagram_container", { 
-    type: "org", 
-    select: true        
+const diagram = new dhx.Diagram("diagram_container", {
+    type: "org",
+    select: true
 });
 // loading data
 diagram.data.parse(data);
@@ -47,7 +47,7 @@ Here's an example of attaching an event handler to the event for the Diagram Edi
 
 ~~~jsx {8-11}
 // initializing Diagram editor
-const editor = new dhx.DiagramEditor("editor_container", {  
+const editor = new dhx.DiagramEditor("editor_container", {
     // config options
 });
 // loading data into the editor
@@ -61,7 +61,7 @@ editor.diagram.events.on("afterUnSelect", ({ id }) => {
 
 **Change log**: Updated in v6.0
 
-**Related articles**:  
+**Related articles**:
 
 - [diagram.config.select](api/diagram/select_property.md)
 - [Selecting items](guides/manipulating_items.md#selecting-items)

--- a/docs/api/selection/beforeselect_event.md
+++ b/docs/api/selection/beforeselect_event.md
@@ -14,7 +14,7 @@ description: You can learn about the beforeSelect event in the documentation of 
 
 ~~~jsx
 "beforeSelect": ({
-    id: string | number, 
+    id: string | number,
     join: boolean,
     batch: (string | number)[]
 }) => boolean | void;
@@ -36,9 +36,9 @@ Return `false` to prevent an item from being selected; otherwise, `true`
 
 ~~~jsx {9-13}
 // initializing Diagram
-const diagram = new dhx.Diagram("diagram_container", { 
-    type: "org", 
-    select: true        
+const diagram = new dhx.Diagram("diagram_container", {
+    type: "org",
+    select: true
 });
 // loading data
 diagram.data.parse(data);
@@ -54,7 +54,7 @@ Here's an example of attaching an event handler to the event for the Diagram Edi
 
 ~~~jsx {8-12}
 // initializing Diagram editor
-const editor = new dhx.DiagramEditor("editor_container", {  
+const editor = new dhx.DiagramEditor("editor_container", {
     // config options
 });
 // loading data into the editor
@@ -69,7 +69,7 @@ editor.diagram.events.on("beforeSelect", ({ id }) => {
 
 **Change log**: Updated in v6.0
 
-**Related articles**:  
+**Related articles**:
 
 - [diagram.config.select](api/diagram/select_property.md)
 - [Selecting items](guides/manipulating_items.md#selecting-items)

--- a/docs/api/selection/beforeunselect_event.md
+++ b/docs/api/selection/beforeunselect_event.md
@@ -14,7 +14,7 @@ description: You can learn about the beforeUnSelect event in the documentation o
 
 ~~~jsx
 "beforeUnSelect": ({
-    id: string | number, 
+    id: string | number,
     batch: (string | number)[]
 }) => void | boolean;
 ~~~
@@ -34,9 +34,9 @@ Return `false` to prevent an item from being unselected; otherwise, `true`
 
 ~~~jsx {9-13}
 // initializing Diagram
-const diagram = new dhx.Diagram("diagram_container", { 
-    type: "org", 
-    select: true        
+const diagram = new dhx.Diagram("diagram_container", {
+    type: "org",
+    select: true
 });
 // loading data
 diagram.data.parse(data);
@@ -52,7 +52,7 @@ Here's an example of attaching an event handler to the event for the Diagram Edi
 
 ~~~jsx {8-12}
 // initializing Diagram editor
-const editor = new dhx.DiagramEditor("editor_container", {  
+const editor = new dhx.DiagramEditor("editor_container", {
     // config options
 });
 // loading data into the editor
@@ -67,7 +67,7 @@ editor.diagram.events.on("beforeUnSelect", ({ id }) => {
 
 **Change log**: Updated in v6.0
 
-**Related articles**:  
+**Related articles**:
 
 - [diagram.config.select](api/diagram/select_property.md)
 - [Selecting items](guides/manipulating_items.md#selecting-items)

--- a/docs/api/selection/clear_method.md
+++ b/docs/api/selection/clear_method.md
@@ -20,8 +20,8 @@ clear(): void;
 
 ~~~jsx {8}
 // a diagram must be created with the "select:true" option
-const diagram = new dhx.Diagram("diagram_container", { 
-    select: true 
+const diagram = new dhx.Diagram("diagram_container", {
+    select: true
 });
 // loading data
 diagram.data.parse(data);
@@ -32,7 +32,7 @@ diagram.selection.clear();
 
 **Change log**: Added in v6.0
 
-**Related articles**:  
+**Related articles**:
 
 - [diagram.config.select](api/diagram/select_property.md)
 - [Selecting items](guides/manipulating_items.md#selecting-items)

--- a/docs/api/selection/getids_method.md
+++ b/docs/api/selection/getids_method.md
@@ -24,8 +24,8 @@ The method returns the list of ids of selected items as an array
 
 ~~~jsx {8}
 // a diagram must be created with the "select:true" option
-const diagram = new dhx.Diagram("diagram_container", { 
-    select: true 
+const diagram = new dhx.Diagram("diagram_container", {
+    select: true
 });
 // loading data
 diagram.data.parse(data);
@@ -35,7 +35,7 @@ const ids = diagram.selection.getIds(); // -> ["1", "1.1", ...] or []
 
 **Change log**: Added in v6.0
 
-**Related articles**:  
+**Related articles**:
 
 - [diagram.config.select](api/diagram/select_property.md)
 - [Selecting items](guides/manipulating_items.md#selecting-items)

--- a/docs/api/selection/getitem_method.md
+++ b/docs/api/selection/getitem_method.md
@@ -34,31 +34,31 @@ The method returns the object of the specified item, if it is in the selection l
 
 ### Example
 
-~~~jsx {9-11,13-15,17-19} 
+~~~jsx {9-11,13-15,17-19}
 // a diagram must be created with the "select:true" option
-const diagram = new dhx.Diagram("diagram_container", { 
-    select: true 
+const diagram = new dhx.Diagram("diagram_container", {
+    select: true
 });
 // loading data
 diagram.data.parse(data);
 
 console.log(diagram.selection.getIds()); // -> ["1", "2", "3"]
 // getting the last selected item
-const item = diagram.selection.getItem(); 
+const item = diagram.selection.getItem();
 // -> {id: "3", text: "Technical Director", title: "Jerry Wagner"}
 
 // getting the selected item by id
-const item = diagram.selection.getItem({ id: "1" }); 
+const item = diagram.selection.getItem({ id: "1" });
 // -> {id: "1", text: "Chairman & CEO", title: "Henry Bennett"}
 
 // trying to get an item which is not in the selection list
-const item = diagram.selection.getItem({ id: "4" }); 
+const item = diagram.selection.getItem({ id: "4" });
 // -> returns undefined, since there is no item with the specified id in the selection list
 ~~~
 
 **Change log**: Updated in v6.0
 
-**Related articles**:  
+**Related articles**:
 
 - [diagram.config.select](api/diagram/select_property.md)
 - [Selecting items](guides/manipulating_items.md#selecting-items)

--- a/docs/api/selection/includes_method.md
+++ b/docs/api/selection/includes_method.md
@@ -32,8 +32,8 @@ The method returns `true` if the element is in the selected list, otherwise `fal
 
 ~~~jsx {9-10}
 // a diagram must be created with the "select:true" option
-const diagram = new dhx.Diagram("diagram_container", { 
-    select: true 
+const diagram = new dhx.Diagram("diagram_container", {
+    select: true
 });
 // loading data
 diagram.data.parse(data);
@@ -45,7 +45,7 @@ diagram.selection.includes({ id: "4" }) // returns false
 
 **Change log**: Added in v6.0
 
-**Related articles**:  
+**Related articles**:
 
 - [diagram.config.select](api/diagram/select_property.md)
 - [Selecting items](guides/manipulating_items.md#selecting-items)

--- a/docs/api/selection/remove_method.md
+++ b/docs/api/selection/remove_method.md
@@ -36,8 +36,8 @@ The method returns `true` if unselection of an item or the list cleanup has been
 
 ~~~jsx {9}
 // a diagram must be created with the "select:true" option
-const diagram = new dhx.Diagram("diagram_container", { 
-    select: true 
+const diagram = new dhx.Diagram("diagram_container", {
+    select: true
 });
 // loading data
 diagram.data.parse(data);
@@ -51,15 +51,15 @@ When called without arguments, the method clears the selection list:
 
 ~~~jsx {9-10}
 // a diagram must be created with the "select:true" option
-const diagram = new dhx.Diagram("diagram_container", { 
-    select: true 
+const diagram = new dhx.Diagram("diagram_container", {
+    select: true
 });
 // loading data
 diagram.data.parse(data);
 
 console.log(diagram.selection.getIds()); // -> ["1", "2", "3"]
 // removes all the items from the selection list
-diagram.selection.remove(); 
+diagram.selection.remove();
 console.log(diagram.selection.getIds()); // -> []
 ~~~
 

--- a/docs/editor_overview.md
+++ b/docs/editor_overview.md
@@ -1,6 +1,6 @@
 ---
-sidebar_label: Diagram Editor overview 
-title: Editor Overview 
+sidebar_label: Diagram Editor overview
+title: Editor Overview
 description: You can have an overview of DHTMLX JavaScript Diagram library in the documentation. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Diagram.
 ---
 
@@ -8,22 +8,22 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 # DHTMLX Diagram Editor overview
 
-The DHTMLX Diagram component provides you with Editor that allows you to try and apply your designer skills in building neat and nice-looking diagrams.
+The DHTMLX Diagram component provides you with an Editor that allows you to try and apply your designer skills in building neat and nice-looking diagrams.
 
 ### Editor in the default mode
 
-The interface of the editor initialized in the default mode consists of four functional parts: 
+The interface of the editor initialized in the default mode consists of four functional parts:
 
 - [toolbar](guides/diagram_editor/toolbar.md)
-- [shapebar](guides/diagram_editor/shapebar.md) 
+- [shapebar](guides/diagram_editor/shapebar.md)
 - [grid area](guides/diagram_editor/grid_area.md)
 - [editbar](guides/diagram_editor/editbar.md)
 
 To build a diagram, you need either to drag the necessary items from the shapebar or create a copy of the items via the shape toolbar.
 
-You can adjust the attributes of the items via [sidebar options of the editbar](guides/diagram_editor/editbar.md). To accelerate the styling process, use `Alt (Option) + Ctrl (Cmd) + С` combination to copy styles of an item and `Alt (Option) + Ctrl (Cmd) + V` to apply these styles to the chosen items.                                      		
+You can adjust the attributes of the items via [sidebar options of the editbar](guides/diagram_editor/editbar.md). To accelerate the styling process, use the `Alt (Option) + Ctrl (Cmd) + С` combination to copy styles of an item and `Alt (Option) + Ctrl (Cmd) + V` to apply these styles to the chosen items.
 
-![](/img/default_editor.png) 
+![](/img/default_editor.png)
 
 **Related sample:** [Diagram Editor. Default mode. Wide flowchart](https://snippet.dhtmlx.com/4d4k3o8p?text=diagram&mode=wide)
 
@@ -31,23 +31,23 @@ You may customize the [shapebar](guides/diagram_editor/shapebar.md) and, if you 
 
 ### Editor in the org chart mode
 
-The interface of the editor initialized in the org chart mode consists of three functional parts: 
+The interface of the editor initialized in the org chart mode consists of three functional parts:
 
 - [toolbar](guides/diagram_editor/toolbar.md)
 - [grid area](guides/diagram_editor/grid_area.md)
 - [editbar](guides/diagram_editor/editbar.md)
 
 :::note
-Note, the editor in this mode does not have the shapebar
+The editor in this mode does not have the shapebar
 :::
 
-To build a diagram in the org chart mode of the editor, you need to select a shape and add a new child for it. You can drag the shapes from one parent item to another. The moved item is being dragged with all its child items.
+To build a diagram in the org chart mode of the editor, you need to select a shape and add a new child for it. You can drag the shapes from one parent item to another. The moved item is dragged with all its child items.
 
-You can adjust the attributes of the shapes via the available [sidebar options of the editbar](guides/diagram_editor/editbar.md). To accelerate the styling process, use `Alt (Option) + Ctrl (Cmd) + С` combination to copy styles of an item and `Alt (Option) + Ctrl (Cmd) + V` to apply these styles to the chosen items.
+You can adjust the attributes of the shapes via the available [sidebar options of the editbar](guides/diagram_editor/editbar.md). To accelerate the styling process, use the `Alt (Option) + Ctrl (Cmd) + С` combination to copy styles of an item and `Alt (Option) + Ctrl (Cmd) + V` to apply these styles to the chosen items.
 
-![](/img/orgchart_editor_draggable.png)     
+![](/img/orgchart_editor_draggable.png)
 
-**Related sample:** [Diagram Editor. Org chart mode. Basic initialization](https://snippet.dhtmlx.com/og4qm3ja?text=diagram&mode=wide)                                             
+**Related sample:** [Diagram Editor. Org chart mode. Basic initialization](https://snippet.dhtmlx.com/og4qm3ja?text=diagram&mode=wide)
 
 If you've added a custom shape to the editor in the org chart mode, you can [configure the editbar](api/diagram_editor/editbar/config/properties_property.md) to be able to edit custom properties of the shape.
 
@@ -58,7 +58,7 @@ You can add the `assistant` or `partner` items for a parent shape of any level. 
   alt="Org chart editor assistant" width='600'
 />
 
-The connection between the parent shape and its partner is always horizontal. Also, the connections between the parent shape and all its children become horizontal after adding a partner item for the parent, even if the connections have been vertical before.                                    
+The connection between the parent shape and its partner is always horizontal. Also, the connections between the parent shape and all its children become horizontal after adding a partner item for the parent, even if the connections have been vertical before.
 
 ### Editor in the mindmap mode
 
@@ -69,16 +69,16 @@ The interface of the editor initialized in the mindmap mode consists of three pa
 - [editbar](guides/diagram_editor/editbar.md)
 
 :::note
-Note, the editor in this mode does not have the shapebar
+The editor in this mode does not have the shapebar
 :::
 
-To build a diagram in the mindmap mode of the editor, you need to select a shape and add a new child for it. You can drag the shapes from one parent item to another. The moved item is being dragged with all its child items.
+To build a diagram in the mindmap mode of the editor, you need to select a shape and add a new child for it. You can drag the shapes from one parent item to another. The moved item is dragged with all its child items.
 
-You can adjust the attributes of the shapes via the available [sidebar options of the editbar](guides/diagram_editor/editbar.md). To accelerate the styling process, use `Alt (Option) + Ctrl (Cmd) + С` combination to copy styles of an item and `Alt (Option) + Ctrl (Cmd) + V` to apply these styles to the chosen items.
+You can adjust the attributes of the shapes via the available [sidebar options of the editbar](guides/diagram_editor/editbar.md). To accelerate the styling process, use the `Alt (Option) + Ctrl (Cmd) + С` combination to copy styles of an item and `Alt (Option) + Ctrl (Cmd) + V` to apply these styles to the chosen items.
 
- ![](/img/mindmap_editor_draggable.png)  
+ ![](/img/mindmap_editor_draggable.png)
 
- **Related sample:** [Diagram Editor. Mindmap mode. Emotions mind map](https://snippet.dhtmlx.com/lo1vm0e8?text=diagram&mode=wide)                                         
+ **Related sample:** [Diagram Editor. Mindmap mode. Emotions mind map](https://snippet.dhtmlx.com/lo1vm0e8?text=diagram&mode=wide)
 
 If you've added a custom shape to the editor in the mindmap mode, you can [configure the editbar](api/diagram_editor/editbar/config/properties_property.md) to be able to edit custom properties of the shape.
 

--- a/docs/groups/configuration_properties.md
+++ b/docs/groups/configuration_properties.md
@@ -1,13 +1,13 @@
 ---
-sidebar_label: Group properties 
+sidebar_label: Group properties
 title: Group Properties
 description: You can learn about the Group properties in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Diagram.
 ---
 
 # Group properties
 
-:::note 
-While specifying color values of the item, use the HEX format.
+:::note
+Specify color values in the HEX format.
 :::
 
 ### Usage
@@ -34,7 +34,7 @@ const data = [
         },
         exitArea?: {
             // "unbound" by default
-            groupBehavior?: "unbound" | "boundNoBorderExtension" | "boundBorderExtension", 
+            groupBehavior?: "unbound" | "boundNoBorderExtension" | "boundBorderExtension",
             padding?: number
         },
         header?: {
@@ -71,25 +71,25 @@ A group object contains a list of configuration properties which allow you to co
 - `width` - (required) the width of the group, including its header (*position: left/right*)
 - `height` - (required) the height of the group, including its header (*position: top/bottom*)
 - `groupChildren` - (optional) an array with ids of the first-level child items of the group
-- `open` - (optional) - defines whether the group is initialized in the expanded (*true*, default) or collapsed (*false*) state
+- `open` - (optional) defines whether the group is initialized in the expanded (*true*, default) or collapsed (*false*) state
 :::tip
 The `open` property works when a `header` is initialized with the `closable` attribute
-::: 
+:::
 - `fixed` - (optional) enables/disables the ability to move and resize the group; *false* by default
 - `style` - (optional) an object with the style settings of the group. The object can contain the following attributes:
     - `strokeWidth` - (optional) the width of the group border, 1 by default
     - `stroke` - (optional) the color of the border of the group, "#DEDEDE" by default
     - `fill` - (optional) the background color of the group
-    - `overFill` - (optional) the background color of the group when the user is holding the item and moving it into/outside the group *providing that the whole item is inside the group*
-    - `partiallyFill` - (optional) the background color of the group when the user is holding the item and moving it into/outside the group *providing that a part of the item is out of the group and other settings are not defined via the `exitArea` attribute*
+    - `overFill` - (optional) the background color of the group when the user is holding the item and moving it into/outside the group *provided that the whole item is inside the group*
+    - `partiallyFill` - (optional) the background color of the group when the user is holding the item and moving it into/outside the group *provided that a part of the item is out of the group and other settings are not defined via the `exitArea` attribute*
 - `exitArea` - (optional) an object with the settings which will be applied to the item when the user is dragging it out of the group (*is applied only to the first-level children of the group*). The object can contain the following attributes:
-    - `groupBehavior` - (optional) the behavior of the child item of the group when the user is moving it out of the group: 
+    - `groupBehavior` - (optional) the behavior of the child item of the group when the user is moving it out of the group:
         - `"unbound"` (by default) - the user can move an item into or outside the group
-        - `"boundNoBorderExtension"` - the user can move an item into the group but cannot drag the item outside the group if the item has been dropped inside the group. The item won't expand the borders of the group when trying to drag the item outside the group
-        - *"boundBorderExtension"* - the user can move an item into the group but cannot drag the item outside the group if the item has been dropped inside the group. The item will expand the borders of the group when trying to drag the item outside the group <br>**Related sample**: [Diagram editor. Default mode. Groups and shapes interaction](https://snippet.dhtmlx.com/4gxy38ek)
-    - `padding` - (optional) defines the padding between the group and the edge of the item when moving the item inside the group 
+        - `"boundNoBorderExtension"` - the user can move an item into the group but cannot drag the item outside the group if the item has been dropped inside the group. The item won't expand the borders of the group when the user tries to drag the item outside the group
+        - `"boundBorderExtension"` - the user can move an item into the group but cannot drag the item outside the group if the item has been dropped inside the group. The item will expand the borders of the group when the user tries to drag the item outside the group <br>**Related sample**: [Diagram editor. Default mode. Groups and shapes interaction](https://snippet.dhtmlx.com/4gxy38ek)
+    - `padding` - (optional) defines the padding between the group and the edge of the item when moving the item inside the group
     :::tip
-    The `padding` attribute is available if *groupBehavior: `"boundNoBorderExtension"` | `"boundBorderExtension"`*
+    The `padding` attribute is available if `groupBehavior` is set to `"boundNoBorderExtension"` or `"boundBorderExtension"`
     :::
 - `header` - (optional) an object with configuration attributes of the header of the group. The attributes are:
     - `height` - (optional) the height of the header, 40 by default
@@ -106,13 +106,13 @@ The `open` property works when a `header` is initialized with the `closable` att
     - `position` - (optional) the positioning of the group header: `"top"` (default) | `"bottom"` | `"left"` | `"right"`
     - `editable` - (optional) enables/disables the ability to edit the text of the header by double-clicking on it; *true* by default
     - `closable` - (optional) shows/hides an icon intended to expand/collapse a group; *false* by default
-    - `enable` - (optional) shows/hides the header of the group; *true* by default 
-- `key` - (optional) your own property with your own logic to be implemented under the hood
+    - `enable` - (optional) shows/hides the header of the group; *true* by default
+- `key` - (optional) a custom property with your own logic, implemented under the hood
 
 ### Example
 
 ~~~jsx
-const data = [    
+const data = [
     {
         type: "$group",
         id: 1,
@@ -188,7 +188,7 @@ When preparing a data set for a `"project"` object, you can use the following co
 - `text` - (optional) the description of a project
 - `open` - (optional) defines whether the project is initialized in the expanded (*true*, default) or collapsed (*false*) state
 
-The properties below are generated automatically. They are calculated during the rendering and shouldn't be specified manually. 
+The properties below are generated automatically. They are calculated during rendering and shouldn't be specified manually.
 
 - `x` - (optional) the x coordinate of the project position
 - `y` - (optional) the y coordinate of the project position
@@ -204,37 +204,37 @@ The properties below are generated automatically. They are calculated during the
     - `text` - (optional) the text to be rendered in the header (generated automatically by the `text` property)
     - `closable` - (optional) shows/hides an icon intended to expand/collapse a group; *false* by default
     - `enable` - (optional) shows/hides the header of the project; *true* by default
-    - `fill` - (optional) the background color of the header 
+    - `fill` - (optional) the background color of the header
 
 
 ### Example
 
-~~~jsx 
+~~~jsx
 const data = [
-    { 
-        "id": "4.2", 
-        "text": "QA Testing", 
-        "type": "project", 
-        "parent": "4", 
-        "start_date": new Date(2026, 1, 18), 
-        "duration": 3, 
-        "progress": 0, 
-        "open": true 
+    {
+        "id": "4.2",
+        "text": "QA Testing",
+        "type": "project",
+        "parent": "4",
+        "start_date": new Date(2026, 1, 18),
+        "duration": 3,
+        "progress": 0,
+        "open": true
     },
-    { 
-        "id": "4.2.1", 
-        "text": "Functional Testing", 
-        "type": "task", 
-        "parent": "4.2", 
-        "start_date": new Date(2026, 1, 18), 
-        "duration": 2 
+    {
+        "id": "4.2.1",
+        "text": "Functional Testing",
+        "type": "task",
+        "parent": "4.2",
+        "start_date": new Date(2026, 1, 18),
+        "duration": 2
     },
-    { 
-        "id": "4.2.2", 
-        "text": "Usability Testing", 
-        "type": "task", 
-        "parent": "4.2", 
-        "start_date": new Date(2026, 1, 20), 
+    {
+        "id": "4.2.2",
+        "text": "Usability Testing",
+        "type": "task",
+        "parent": "4.2",
+        "start_date": new Date(2026, 1, 20),
         "duration": 1
     }
 ];

--- a/docs/groups/index.md
+++ b/docs/groups/index.md
@@ -8,7 +8,7 @@ description: You can learn about Groups in the documentation of the DHTMLX JavaS
 
 ## Group overview
 
-A group is a separate kind of the Diagram items. You can draw simple or more complicated schemes by grouping shapes or other groups in different ways. It is possible to create as one-level groups as nested groups, to configure their appearance and behavior.
+A group is a separate kind of Diagram item. You can draw simple or more complicated schemes by grouping shapes or other groups in different ways. You can create both one-level and nested groups, and configure their appearance and behavior.
 
 :::note
 Groups are available only in the default mode of Diagram/Diagram Editor (type: `"default"`).
@@ -65,30 +65,30 @@ To group the `"task"` and `"milestone"` types of shapes in the PERT mode of the 
 
 ~~~jsx
 const data = [
-    { 
-        "id": "4.2", 
-        "text": "QA Testing", 
-        "type": "project", 
-        "parent": "4", 
-        "start_date": new Date(2026, 1, 18), 
-        "duration": 3, 
-        "progress": 0, 
-        "open": true 
+    {
+        "id": "4.2",
+        "text": "QA Testing",
+        "type": "project",
+        "parent": "4",
+        "start_date": new Date(2026, 1, 18),
+        "duration": 3,
+        "progress": 0,
+        "open": true
     },
-    { 
-        "id": "4.2.1", 
-        "text": "Functional Testing", 
-        "type": "task", 
-        "parent": "4.2", 
-        "start_date": new Date(2026, 1, 18), 
-        "duration": 2 
+    {
+        "id": "4.2.1",
+        "text": "Functional Testing",
+        "type": "task",
+        "parent": "4.2",
+        "start_date": new Date(2026, 1, 18),
+        "duration": 2
     },
-    { 
-        "id": "4.2.2", 
-        "text": "Usability Testing", 
-        "type": "task", 
-        "parent": "4.2", 
-        "start_date": new Date(2026, 1, 20), 
+    {
+        "id": "4.2.2",
+        "text": "Usability Testing",
+        "type": "task",
+        "parent": "4.2",
+        "start_date": new Date(2026, 1, 20),
         "duration": 1
     }
 ];
@@ -107,8 +107,8 @@ The header of the group is disabled by default. To create a group with the heade
 ~~~jsx
 const data = [
     {
-        type: "$group", 
-        id: 1, 
+        type: "$group",
+        id: 1,
         width: 400,
         height: 200,
         x: 0,
@@ -118,7 +118,7 @@ const data = [
 ];
 ~~~
 
-The property contains a lot of attributes which allow you to easily adjust the configuration of the group header.
+The property contains several attributes which allow you to easily adjust the configuration of the group header.
 For example, you can define the height of the header and its position, specify the text for your header and adjust its settings.
 
 <iframe src="https://snippet.dhtmlx.com/6hunrja8?mode=js" frameborder="0" class="snippet_iframe" width="100%" height="470"></iframe>
@@ -127,13 +127,13 @@ Check [the full list of API properties of the group object](groups/configuration
 
 ### A header icon
 
-To be able to collapse/expand a group, you need to enable the `closable` attribute of the [header](groups/configuration_properties.md) property. As a result, an icon, which allows a user to expand/collapse a group, will be added to the header.
+To collapse or expand a group, enable the `closable` attribute of the [header](groups/configuration_properties.md) property. As a result, an icon, which allows a user to expand/collapse a group, will be added to the header.
 
 ~~~jsx
 const data = [
     {
-        type: "$group", 
-        id: 1, 
+        type: "$group",
+        id: 1,
         width: 400,
         height: 200,
         x: 0,
@@ -151,7 +151,7 @@ You can change the color of the icon via the `iconColor` attribute of the [group
 ## Configuring the behavior of group items
 
 By default, you can drag any child item of the group out of the group and drag it into another group.
-To change the behavior of the group items you need to use the `groupBehavior` and `padding` attributes of the `exitArea` property of the [group object](groups/configuration_properties.md).
+To change how the group items behave, use the `groupBehavior` and `padding` attributes of the `exitArea` property of the [group object](groups/configuration_properties.md).
 
 :::note
 The `exitArea` property defines the behavior of the first-level children of the configurable group only.
@@ -159,11 +159,11 @@ The `exitArea` property defines the behavior of the first-level children of the 
 
 <iframe src="https://snippet.dhtmlx.com/4gxy38ek?mode=js" frameborder="0" class="snippet_iframe" width="100%" height="550"></iframe>
 
-The `"unbound"` and `"boundBorderExtension"` values of the `groupBehavior` attribute allows you to define whether the child items can be moved out of the group, and to make the group borders expand when a user is trying to drag an item outside. If needed you can also disable the ability to drag items outside the group via the `"boundNoBorderExtension"` value.
+The `"unbound"` and `"boundBorderExtension"` values of the `groupBehavior` attribute allow you to define whether the child items can be moved out of the group, and to make the group borders expand when a user is trying to drag an item outside. If needed, you can also disable the ability to drag items outside the group via the `"boundNoBorderExtension"` value.
 
 ![](/img/group_behavior.gif)
 
-If *groupBehavior: `"boundNoBorderExtension"` | `"boundBorderExtension"`* is set, you can specify the padding between the group and the edge of the item when moving the item inside the group. For this purpose, use the `padding` attribute:
+If `groupBehavior` is set to `"boundNoBorderExtension"` or `"boundBorderExtension"`, you can specify the padding between the group and the edge of the item when moving the item inside the group. For this purpose, use the `padding` attribute:
 
 ~~~jsx
 const data = [

--- a/docs/guides/ai-integrations/ai-demo.md
+++ b/docs/guides/ai-integrations/ai-demo.md
@@ -4,7 +4,7 @@ title: Building AI-powered Diagram
 description: Step-by-step guide to running the DHTMLX Diagram AI demo. Text-to-diagram org chart generation using the OpenAI API, with a live preview and JSON editor.
 ---
 
-# Building AI-powered Diagram  
+# Building AI-powered Diagram
 
 DHTMLX Diagram can be integrated with AI for creating AI-powered diagramming applications. We have prepared an example on how to use DHTMLX Diagram with AI to build an application for creating an org chart out of a request provided in natural language.
 
@@ -18,7 +18,7 @@ To download the project, clone the repository by using the following command:
 git clone diagram-org-chart-builder-ai-demo
 ~~~
 
-and then go the project repository via the command below:
+and then go to the project repository via the command below:
 
 ~~~jsx
 cd diagram-org-chart-builder-ai-demo
@@ -26,7 +26,7 @@ cd diagram-org-chart-builder-ai-demo
 
 ### Installing dependencies
 
-To install dependencies and run the app, you need to make use of a package manager. To install the demo app described in this guide, you should use [npm](https://www.npmjs.com/) by calling the following command:
+To install dependencies and run the app, you need a package manager. This guide uses [npm](https://www.npmjs.com/) — install the demo app by calling the following command:
 
 ~~~jsx
 npm install
@@ -34,7 +34,7 @@ npm install
 
 ### Adjusting environment variables
 
-Then you need to configure the environment variables. For this, create a new file named `.env` inside the **diagram-org-chart-builder-ai-demo** directory by copying the content of the `env.sample` file. 
+Then you need to configure the environment variables. For this, create a new file named `.env` inside the **diagram-org-chart-builder-ai-demo** directory by copying the content of the `env.sample` file.
 The newly created `.env` file will store your keys and configuration. Fill in the required values provided below:
 
 ~~~jsx title="diagram-org-chart-builder-ai-demo/.env"
@@ -71,7 +71,7 @@ npm start // this is the required start command
 You should see the output below in your terminal:
 
 ~~~jsx
-Server started on port 3001. 
+Server started on port 3001.
 ~~~
 
 Then open the web browser and navigate to: `http://localhost:3001` to see the application ready to generate diagrams.
@@ -83,7 +83,7 @@ These are the basic steps for transforming a text request into a diagram:
 - First, the user enters a text description of the diagram in plain terms, for example: "A diagram with a top manager and five departments each having two employees".
 - Then the prompt is sent to the backend, where the AI service generates a structured JSON configuration based on the request.
 - After that the frontend gets the resulting data and renders an interactive DHTMLX diagram instantly.
-- At the following stage, the corresponding JSON code is displayed in the code editor below the diagram. The user can fine-tune the code and edit the resulting diagram in real time.
+- Next, the corresponding JSON code is displayed in the code editor below the diagram. The user can fine-tune the code and edit the resulting diagram in real time.
 - Finally, the user can save the generated data in a JSON file or export the diagram to a PDF or PNG file.
 
 

--- a/docs/guides/ai-integrations/mcp-server.md
+++ b/docs/guides/ai-integrations/mcp-server.md
@@ -115,7 +115,7 @@ These are the steps to complete for connecting DHTMLX MCP server with Google Ant
 ~~~
 dhtmlx-mcp
 ~~~
-- URL: 
+- URL:
 ~~~
 https://docs.dhtmlx.com/mcp
 ~~~
@@ -158,11 +158,11 @@ Follow these steps to connect DHTMLX MCP server to ChatGPT:
 3. Enable **Developer mode**
 4. Return to the **Apps & Connectors** screen and click "Create"
 5. Configure the connector:
-- Name: 
+- Name:
 ~~~
 dhtmlx-mcp
 ~~~
-- URL: 
+- URL:
 ~~~
 https://docs.dhtmlx.com/mcp
 ~~~

--- a/docs/guides/customization.md
+++ b/docs/guides/customization.md
@@ -1,12 +1,12 @@
 ---
-sidebar_label: Customizing items 
+sidebar_label: Customizing items
 title: Customizing Items
 description: You can learn about customizing items in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Diagram.
 ---
 
 # Customizing items
 
-You can easily modify the appearance of diagram items by using various [configuration properties](/category/items-api/) inside their objects. Besides, you can change the look and feel of the diagram according to your needs by creating custom shapes of the desired appearance.
+You can modify the appearance of diagram items by using various [configuration properties](/category/items-api/) inside their objects. You can also change the look and feel of the diagram by creating custom shapes.
 
 ## Styling shapes and lines via the configuration properties
 
@@ -40,7 +40,7 @@ const defaults = {
 
 ### Styling lines
 
-To change the look of connector lines, use the necessary configuration properties inside the line object. 
+To change the look of connector lines, use the necessary configuration properties inside the line object.
 
 ~~~jsx
 const data = [
@@ -86,7 +86,7 @@ You can create a customized diagram by adding new types of shapes into the diagr
 While using the org and mindmap charts in the Diagram Editor, you can add a custom style for target items.
 
 :::note
-The stylization doesn't work with the parent item of the moved item and with the moved item with the property `giveItem: false`
+The stylization doesn't apply to the parent of the moved item, or to a moved item that has `giveItem: false`
 :::
 
 ~~~jsx

--- a/docs/guides/data_export.md
+++ b/docs/guides/data_export.md
@@ -6,7 +6,7 @@ description: You can learn about exporting Diagram in the documentation of the D
 
 # Exporting Diagram
 
-You can easily export a diagram into the PDF or PNG format via the related [pdf()](api/export/pdf_method.md)/[png()](api/export/png_method.md) methods of the Export object:
+You can export a diagram into the PDF or PNG format via the related [pdf()](api/export/pdf_method.md)/[png()](api/export/png_method.md) methods of the Export object:
 
 <iframe src="https://snippet.dhtmlx.com/ybpmz0zk?mode=html" frameborder="0" class="snippet_iframe" width="100%" height="600"></iframe>
 
@@ -19,23 +19,23 @@ Check the list of available settings:
 
 ## Exporting styles
 
-By default, all css styles included to the Diagram page are sent to the export service when exporting the diagram. As a result, the size of the request increases that can cause the request to fail.
+By default, all CSS styles included on the Diagram page are sent to the export service. As a result, the request size increases, which can cause it to fail.
 
 The library allows you:
 
-- to prevent all styles from being sent to the export service via setting
+- to prevent all styles from being sent to the export service by setting
 the [`exportStyles`](api/diagram/exportstyles_property.md) configuration property of the Diagram object to *false*:
 
 ~~~jsx
-const diagram = new dhx.Diagram("diagram_container", { 
+const diagram = new dhx.Diagram("diagram_container", {
     exportStyles: false
 });
 ~~~
 
-- to define a set of styles that you want to be exported via setting absolute paths to the desired styles to the [`exportStyles`](api/diagram/exportstyles_property.md) array:
+- to define a set of styles that you want to be exported by setting absolute paths to the desired styles in the [`exportStyles`](api/diagram/exportstyles_property.md) array:
 
 <iframe src="https://snippet.dhtmlx.com/jm8if6nh?mode=result" frameborder="0" class="snippet_iframe" width="100%" height="650"></iframe>
 
 :::note
-**Note**, that you must use only absolute paths not relative ones.
+You must use only absolute paths, not relative ones.
 :::

--- a/docs/guides/diagram/configuration.md
+++ b/docs/guides/diagram/configuration.md
@@ -1,5 +1,5 @@
 ---
-sidebar_label: Configuration 
+sidebar_label: Configuration
 title: Diagram Configuration
 description: You can learn about the Diagram Configuration in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Diagram.
 ---
@@ -10,7 +10,7 @@ DHTMLX Diagram provides a wide range of options for configuration. You can chang
 
 ### Setting the Diagram mode
 
-There are the following Diagram modes you can choose from: `"default"`, `"org"`, `"mindmap"`, `"pert"`. Their detailed description is given in the [Diagram overview](/) article. You can specify the necessary type via the [type](api/diagram/type_property.md) configuration option, as follows:
+You can choose from the following Diagram modes: `"default"`, `"org"`, `"mindmap"`, `"pert"`. Their detailed description is given in the [Diagram overview](/) article. You can specify the necessary type via the [type](api/diagram/type_property.md) configuration option, as follows:
 
 ~~~jsx
 const diagram = new dhx.Diagram("diagram_container", {
@@ -21,11 +21,11 @@ diagram.data.parse(data);
 
 ### Setting the default shape type
 
-It is possible to set the default type for all the shapes via the [`defaultShapeType`](api/diagram/defaultshapetype_property.md) attribute of the diagram configuration object:
+You can set the default type for all the shapes via the [`defaultShapeType`](api/diagram/defaultshapetype_property.md) attribute of the diagram configuration object:
 
 ~~~jsx {3}
 const diagram = new dhx.Diagram("diagram_container", {
-    type: "default", // or type: "org", or type: "mindmap" 
+    type: "default", // or type: "org", or type: "mindmap"
     defaultShapeType: "rectangle"
 });
 diagram.data.parse(data);
@@ -58,7 +58,7 @@ This value is applied, if the line object doesn't contain the `type` property.
 
 ## Setting the default configuration of a shape
 
-There is a great possibility to escape operating with a big data set while preparing it for loading into the diagram. You can specify the default configuration for all shapes and lines of the necessary types and, therefore, reduce the amount of records in your code.
+You can avoid working with a large data set while preparing it for loading into the diagram. You can specify the default configuration for all shapes and lines of the necessary types and, therefore, reduce the number of records in your code.
 
 For this purpose, use the [`defaults`](api/diagram/defaults_property.md) property of the diagram configuration object:
 
@@ -170,7 +170,7 @@ DHTMLX Diagram allows you to specify a toolbar with icons for Diagram shapes to 
 
 ## Enabling items selection
 
-It is possible to activate selection of items in a diagram. You need to make use of the [`select`](api/diagram/select_property.md) attribute of the diagram configuration object. Once you've enabled selection in a diagram, you can make use of the Selection object API to [work with the items selection](guides/manipulating_items.md#selecting-items).
+You can activate selection of items in a diagram via the [`select`](api/diagram/select_property.md) attribute of the diagram configuration object. Once you've enabled selection in a diagram, you can use the Selection object API to [work with the items selection](guides/manipulating_items.md#selecting-items).
 
 :::note
 [The predefined set of events](/api/selection/#events) of the selection object can help you to define the way of processing the behavior of the diagram during selecting/unselecting items

--- a/docs/guides/diagram/initialization.md
+++ b/docs/guides/diagram/initialization.md
@@ -1,12 +1,12 @@
 ---
-sidebar_label: Initialization 
+sidebar_label: Initialization
 title: Initialization
 description: You can learn how to start with Diagram in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Diagram.
 ---
 
 # Diagram initialization
 
-In this article we will discuss the stages of adding DHTMLX Diagram on a page. This process presupposes several simple steps:
+In this article, we will discuss the stages of adding DHTMLX Diagram to a page. This process involves several simple steps:
 
 - [Download the DHTMLX Diagram package](https://dhtmlx.com/docs/products/dhtmlxDiagram/download.shtml) and unpack it into a folder of your project
 - [Include the DHTMLX Diagram source files on a page](#including-required-code-files)
@@ -17,7 +17,7 @@ In this article we will discuss the stages of adding DHTMLX Diagram on a page. T
 <!DOCTYPE html>
 <html>
 <head>
-    <script type="text/javascript" src="codebase/diagram.js"></script>	
+    <script type="text/javascript" src="codebase/diagram.js"></script>
     <link rel="stylesheet" href="codebase/diagram.css">
 </head>
 
@@ -25,7 +25,7 @@ In this article we will discuss the stages of adding DHTMLX Diagram on a page. T
     <div id="diagram_container"></div>
     <script>
         // preparing diagram data
-        const data = [ 
+        const data = [
             { id: 1, x: 100, y: 40, text: "Start", type: "start", height: 50 },
             { id: 2, x: 100, y: 170, text: "Operation 1", type: "output" },
             { id: 3, x: 100, y: 300, text: "Operation 2", type: "input" },
@@ -56,13 +56,13 @@ To create Diagram, you need to include 2 source files on your page:
 Make sure that you set correct relative paths to these files:
 
 ~~~html
-<script type="text/javascript" src="../codebase/diagram.js"></script>	
+<script type="text/javascript" src="../codebase/diagram.js"></script>
 <link rel="stylesheet" href="../codebase/diagram.css">
 ~~~
 
-The structure of DHTMLX Diagram package is the following: 
+The structure of DHTMLX Diagram package is the following:
 
-- **sources** - the source code files of the library. The files are not minified and easy-to-read. The package is mostly intended to be used for component's debugging
+- **sources** - the source code files of the library. The files are not minified and are easy to read. The package is mostly intended to be used for component's debugging
 
 :::note
 Note that the **Trial** version of the Diagram library doesn't contain the sources folder.
@@ -98,7 +98,7 @@ const diagram = new dhx.Diagram("diagram_container", {
 
 ### Initialization in the document body
 
-It is possible to skip setting a container for Diagram and to add it right into the document's body:
+You can skip setting a container for Diagram and add it directly into the document body:
 
 ~~~jsx
 const diagram = new dhx.Diagram(document.body, {
@@ -127,7 +127,7 @@ layout.getCell("diagram").attach(diagram);
 
 ### Configuration properties
 
-To change the [configuration of a diagram](guides/diagram/configuration.md), you can specify the desired property in the config object passed as a second parameter of the constructor function. 
+To change the [configuration of a diagram](guides/diagram/configuration.md), you can specify the desired property in the config object passed as a second parameter of the constructor function.
 
 ~~~jsx
 const diagram = new dhx.Diagram("diagram_container", {
@@ -138,7 +138,7 @@ const diagram = new dhx.Diagram("diagram_container", {
 
 See [the full list of configuration properties of Diagram](api/diagram/api_overview.md#diagram-properties).
 
-**Related sample**:	[Diagram Editor. Default mode. Wide flowchart](https://snippet.dhtmlx.com/4d4k3o8p)	
+**Related sample**:	[Diagram Editor. Default mode. Wide flowchart](https://snippet.dhtmlx.com/4d4k3o8p)
 
 Alternatively, you can get access to some option and set/modify its value via the diagram `config` object. Don't forget to call the [`paint()`](api/diagram/paint_method.md) method to re-render the diagram with a new configuration:
 

--- a/docs/guides/diagram/scrolling_diagram.md
+++ b/docs/guides/diagram/scrolling_diagram.md
@@ -37,6 +37,6 @@ You can catch the start of Diagram scrolling using the [`scroll`](api/diagram/sc
 
 ~~~jsx
 diagram.events.on("Scroll", (position) => {
-    alert("The diagram has been scrolled:" position);
+    alert("The diagram has been scrolled:" + position);
 });
 ~~~

--- a/docs/guides/diagram/scrolling_diagram.md
+++ b/docs/guides/diagram/scrolling_diagram.md
@@ -6,7 +6,7 @@ description: You can learn about scrolling Diagram in the documentation of the D
 
 # Scrolling Diagram
 
-By default the component's size is set automatically to fit the content. If necessary, the component will take the size of the HTML container and render horizontal and vertical inner scrolls to fit the content.
+By default, the component's size is set automatically to fit the content. If necessary, the component will take the size of the HTML container and render horizontal and vertical inner scrolls to fit the content.
 
 ## Scrolling diagram
 
@@ -14,11 +14,11 @@ You can scroll a diagram to the area where the necessary item is situated via th
 
 <iframe src="https://snippet.dhtmlx.com/d7kvzq4r?mode=result" frameborder="0" class="snippet_iframe" width="100%" height="600"></iframe>
 
-As an alternative way, you can scroll to the necessary position on the diagram by using the [`scrollTo()`](api/diagram/scrollto_method.md) method.
+Alternatively, you can scroll to the necessary position on the diagram by using the [`scrollTo()`](api/diagram/scrollto_method.md) method.
 
 <iframe src="https://snippet.dhtmlx.com/f970hbym?mode=result" frameborder="0" class="snippet_iframe" width="100%" height="600"></iframe>
 
-## Getting scroll state 
+## Getting scroll state
 
 The Diagram API allows you to get the current position of the scroll via the related [`getScrollState()`](api/diagram/getscrollstate_method.md) method:
 

--- a/docs/guides/diagram_editor/editbar.md
+++ b/docs/guides/diagram_editor/editbar.md
@@ -33,7 +33,7 @@ To configure a [group of elements](guides/items_index.md), you need to use the f
 - [`$shape`](#configure-editbar-for-shapes) - allows configuring Editbar controls for [all shapes including custom shapes](/category/shapes)
 - [`$group`](#configure-editbar-for-group-elements) - allows configuring Editbar controls for all elements with the [`group`](/groups/) type
 - [`$swimlane`](#configure-editbar-for-swimlanes) - allows configuring Editbar controls for all elements with the [`swimlane`](/swimlanes/) type
-- [`$line`](#configure-editbar-for-lines) allows configuring Editbar controls for all elements with the [`line`](/lines/) type
+- [`$line`](#configure-editbar-for-lines) - allows configuring Editbar controls for all elements with the [`line`](/lines/) type
 - [`$lineTitle`](#configure-editbar-for-line-titles) - allows configuring Editbar controls for all elements with the [`lineTitle`](/line_titles/) type
 
 <iframe src="https://snippet.dhtmlx.com/ealq0m4l?mode=js" frameborder="0" class="snippet_iframe" width="100%" height="600"></iframe>
@@ -84,10 +84,10 @@ The `$group` service property allows configuring Editbar controls for all elemen
 ~~~jsx
 properties: {
     $group: [
-        { 
-            type: "header", 
+        {
+            type: "header",
             label: "Group header style",
-            // ... 
+            // ...
         }
     ]
 }
@@ -102,10 +102,10 @@ The `$swimlane` service property allows configuring Editbar controls for all ele
 ~~~jsx
 properties: {
     $swimlane: [
-        { 
-            type: "header", 
+        {
+            type: "header",
             label: "Swimlane header style",
-            // ... 
+            // ...
         }
     ]
 }
@@ -155,7 +155,7 @@ properties: {
 You can use the [`controls`](api/diagram_editor/editbar/config/controls_property.md) property of the Editbar view to create a custom control based on [**Basic controls**](api/diagram_editor/editbar/basic_controls_overview.md) and/or [**Complex controls**](api/diagram_editor/editbar/complex_controls_overview.md).
 
 :::warning
-We do not recommend you to use a default control type (refer to the [***Basic controls***](api/diagram_editor/editbar/basic_controls_overview.md) and/or [***Complex controls***](api/diagram_editor/editbar/complex_controls_overview.md)) as the name for a custom control. Use the unique name for each custom control to avoid errors!
+We do not recommend using a default control type (refer to the [***Basic controls***](api/diagram_editor/editbar/basic_controls_overview.md) and/or [***Complex controls***](api/diagram_editor/editbar/complex_controls_overview.md)) as the name for a custom control. Use a unique name for each custom control to avoid errors!
 :::
 
 After creating a custom control, you need to apply it to the needed Diagram element via the [`properties`](api/diagram_editor/editbar/config/properties_property.md) property.

--- a/docs/guides/diagram_editor/grid_area.md
+++ b/docs/guides/diagram_editor/grid_area.md
@@ -1,14 +1,14 @@
 ---
-sidebar_label: Grid area 
+sidebar_label: Grid area
 title: Editor Guides - Grid Area
 description: You can learn about the Grid Area of editor in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Diagram.
 ---
 
 # Grid area
 
-Grid area is an area intended for editing a diagram. You can easily add new items, change their appearance and positioning, or remove them.
+Grid area is an area intended for editing a diagram. You can add new items, change their appearance and positioning, or remove them.
 
-In this section you will find what interface elements are available for each diagram item depending on the mode the editor is initialized in. The section also explains how to facilitate ease of designing a diagram by using keyboard shortcuts or operating several selected items at once.
+In this section you will find what interface elements are available for each diagram item depending on the mode the editor is initialized in. The section also explains how to simplify designing a diagram by using keyboard shortcuts or operating several selected items at once.
 
 :::note
 Distance between points in the Grid area depends on the value of the [grid step](api/diagram_editor/editor/config/gridstep_property.md)
@@ -121,11 +121,11 @@ When you click on any swimlane, it becomes editable and gets personal interface 
     - `"remove"` - to delete the selected swimlane
 - resizing handles (pull the handles of the editable swimlane to change its sizes)
 
-Besides, there are the abilities to add, move, or remove columns or rows of the swimlane via the options of the context menu. The context menu will appear after the user clicks on the icon of a swimlane subheader.
+You can also add, move, or remove columns or rows of the swimlane via the context menu options. The context menu will appear after the user clicks on the icon of a swimlane subheader.
 
 ![](/img/swimlane_contextmenu.png)
 
-Note, that some options of moving the first/last columns and rows are deactivated by internal settings of a swimlane.
+Note that some options of moving the first/last columns and rows are deactivated by internal settings of a swimlane.
 
 ## Editing attributes of an item
 
@@ -147,7 +147,7 @@ If you need to change the width and color of the lines, or to hide them at all, 
 
 ## Manipulating multiple items
 
-It is possible to select several diagram items via hovering them over with the left mouse button pressed. You can also select necessary items using keyboard shortcuts - Shift+Left Click.
+You can select several diagram items by hovering over them with the left mouse button pressed. You can also select necessary items using keyboard shortcuts - Shift+Left Click.
 
 You can operate all the selected items at once, namely:
 

--- a/docs/guides/diagram_editor/hot_keys.md
+++ b/docs/guides/diagram_editor/hot_keys.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Hotkeys
-title: Editor Guides - Hotkey List 
+title: Editor Guides - Hotkey List
 description: You can learn about the Hotkeys of editor in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Diagram.
 ---
 

--- a/docs/guides/diagram_editor/initialization.md
+++ b/docs/guides/diagram_editor/initialization.md
@@ -1,12 +1,12 @@
 ---
-sidebar_label: Initialization 
+sidebar_label: Initialization
 title: Diagram Editor initialization
 description: You can learn how to start with Diagram Editor in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Diagram.
 ---
 
 # Diagram Editor initialization
 
-This article covers the process of displaying a Diagram Editor on a page. In order to initialize the editor, you need to include source files specific for Editor and use the `DiagramEditor` instance. In all other aspects the initialization stage is the same as for the Diagram component:
+This article covers the process of displaying a Diagram Editor on a page. To initialize the editor, you need to include source files specific to Editor and use the `DiagramEditor` instance. In all other aspects the initialization stage is the same as for the Diagram component:
 
 - [Download the DHTMLX Diagram package](https://dhtmlx.com/docs/products/dhtmlxDiagram/download.shtml) and unpack it into a folder of your project
 - [Include the source files on a page](#including-required-code-files)
@@ -25,7 +25,7 @@ This article covers the process of displaying a Diagram Editor on a page. In ord
     <div id="editor_container"></div>
     <script>
         // preparing data
-        const data = [ 
+        const data = [
             { id: 1, x: 100, y: 40, text: "Start", type: "start", height: 50 },
             { id: 2, x: 100, y: 170, text: "Operation 1", type: "output" },
             { id: 3, x: 100, y: 300, text: "Operation 2", type: "input" },
@@ -67,7 +67,7 @@ You can import JavaScript Diagram Editor into your project using the `yarn` or `
 #### Installing trial Diagram Editor via npm or yarn
 
 :::info
-If you want to use the trial version of Diagram Editor, download the [**trial Diagram package**](https://dhtmlx.com/docs/products/dhtmlxDiagram/download.shtml) and follow the steps mentioned in the *README* file. Note that the trial Diagram Editor is available 30 days only.
+If you want to use the trial version of Diagram Editor, download the [**trial Diagram package**](https://dhtmlx.com/docs/products/dhtmlxDiagram/download.shtml) and follow the steps mentioned in the *README* file. Note that the trial Diagram Editor is available for 30 days only.
 :::
 
 #### Installing PRO Diagram Editor via npm or yarn
@@ -100,7 +100,7 @@ const editor = new dhx.DiagramEditor("editor_container", {
 
 ### Initialization in the document body
 
-It is also possible to skip setting a container for Diagram Editor and to add it right into the document's body:
+You can also skip setting a container for Diagram Editor and add it directly into the document body:
 
 ~~~jsx
 const editor = new dhx.DiagramEditor(document.body, {
@@ -145,6 +145,6 @@ Check [the full list of configuration properties of Editor](api/diagram_editor/e
 
 ## Loading data into Diagram Editor
 
-It is possible to load an [appropriate data set](guides/loading_data.md#preparing-data-to-load) into the editor via the [parse()](api/diagram_editor/editor/methods/parse_method.md) method of the editor.
+You can load an [appropriate data set](guides/loading_data.md#preparing-data-to-load) into the editor via the [parse()](api/diagram_editor/editor/methods/parse_method.md) method of the editor.
 
 <iframe src="https://snippet.dhtmlx.com/xshe9ut7?mode=result" frameborder="0" class="snippet_iframe" width="100%" height="600"></iframe>

--- a/docs/guides/diagram_editor/shapebar.md
+++ b/docs/guides/diagram_editor/shapebar.md
@@ -4,11 +4,11 @@ title: Editor Guides - Shapebar
 description: You can learn about the Shapebar of editor in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Diagram.
 ---
 
-# Shapebar 
+# Shapebar
 
 Shapebar is a part of the editor that renders previews of Diagram items. You can choose the necessary items and drag them from the shapebar into the grid area.
 
-:::note 
+:::note
 The shapebar is available only in the editor initialized in the default mode (type: `"default"`).
 :::
 
@@ -102,7 +102,7 @@ You can reconfigure any type of shapes in such a way.
 
 4. Combining different types of items in a section
 
-If your project presupposes usage of various elements, you can create sections with mixed types of items in the Shapebar. Check the following example:
+If your project uses various elements, you can create sections with mixed types of items in the Shapebar. Check the following example:
 
 ~~~jsx
 const editor = new dhx.DiagramEditor("editor_container", {
@@ -145,7 +145,7 @@ To do that, you need to:
 
 ## Setting the preview of shapes
 
-To configure the preview of items rendered in the shapebar of the editor, make use of the [`preview`](api/diagram_editor/shapebar/config/preview_property.md) property. It is an object that contains two attributes:
+To configure the preview of items rendered in the shapebar of the editor, use the [`preview`](api/diagram_editor/shapebar/config/preview_property.md) property. It is an object that contains two attributes:
 
 - `scale` - (optional) defines the scale of items rendered in the shapebar of the editor, 0.5 by default
 - `gap` - (optional) specifies the space between the items rendered in the shapebar, "6px 8px" by default
@@ -176,13 +176,13 @@ The property can be applied in two cases:
 
 Let's consider three examples of configuring a shape preview:
 
-1\. You can specify an image to be shown in the shapebar for a custom shape. For this purpose, you need to pass either an URL to load an image from or a base64 image as a string value to the `preview` property:
+1\. You can specify an image to be shown in the shapebar for a custom shape. For this purpose, you need to pass either a URL to load an image from or a base64 image as a string value to the `preview` property:
 
 ~~~jsx {6}
 const defaults = {
-    title: "Name and First name", 
-    img: "../avatar-1.jpg", 
-    height: 115, 
+    title: "Name and First name",
+    img: "../avatar-1.jpg",
+    height: 115,
     width: 330,
     preview: "../shape_preview.png"
 };
@@ -199,9 +199,9 @@ editor.diagram.addShape("template", {
 const defaults = {
     title: "Name and First name", email: "some@mail.com",
     img: "../avatar-1.jpg", height: 115, width: 330,
-    preview: { 
-        img: "../shape_preview.png", 
-        height: 58, 
+    preview: {
+        img: "../shape_preview.png",
+        height: 58,
         width: 165
     }
 }
@@ -212,7 +212,7 @@ editor.diagram.addShape("template", {
 });
 ~~~
 
-:::note 
+:::note
 You can set the precise width and height of the image, but there is no ability to set the scale of the image.
 :::
 
@@ -247,7 +247,7 @@ editor.diagram.addShape("personalCard", {
 ~~~
 
 :::note
-**Note**, that the `preview` property will be omitted when exporting data to the JSON format.
+The `preview` property will be omitted when exporting data to the JSON format.
 :::
 
 ## Setting the width of shapebar
@@ -265,9 +265,9 @@ const editor = new dhx.DiagramEditor("editor_container", {
 });
 ~~~
 
-## Showing/hiding the Shapebar  
+## Showing/hiding the Shapebar
 
-Whenever you need to control the visibility of a shapebar, you can use the [`show`](api/diagram_editor/shapebar/config/show_property.md) property. It allows you to hide the shapebar with particular settings on initialization of the Diagram Editor and show it later, when needed. By default the shapebar is shown.
+Whenever you need to control the visibility of a shapebar, you can use the [`show`](api/diagram_editor/shapebar/config/show_property.md) property. It allows you to hide the shapebar with particular settings on initialization of the Diagram Editor and show it later, when needed. By default, the shapebar is shown.
 
 ~~~jsx
 const editor = new dhx.DiagramEditor("editor_container", {

--- a/docs/guides/diagram_editor/toolbar.md
+++ b/docs/guides/diagram_editor/toolbar.md
@@ -6,7 +6,7 @@ description: You can learn about the Toolbar of editor in the documentation of t
 
 # Toolbar
 
-Toolbar is a top part of Diagram Editor that helps users to control the editing process.
+Toolbar is a top part of Diagram Editor that helps users control the editing process.
 
 ![](/img/diagram-editor-toolbar/scale-default-mode.png)
 
@@ -257,11 +257,11 @@ Toolbar items are represented by **service elements**. You can use and configure
 
 - `resizePoints` - shows/hides the **resize points**
 
-- `magnetic` - turns on/of the `magnetic` functionality
+- `magnetic` - turns on/off the `magnetic` functionality
 
-- `zoomIn` - decreases the scale value by 0.05 (5%)
+- `zoomIn` - increases the scale value by 0.05 (5%)
 
-- `zoomOut` - increases the scale value by 0.05 (5%)
+- `zoomOut` - decreases the scale value by 0.05 (5%)
 
 <hr>
 
@@ -360,7 +360,7 @@ Toolbar items are represented by **service elements**. You can use and configure
 
 - `alignVerticalBottom` - aligns elements vertically at the bottom
 
-- `distribute` - forms a group of service elements for distributing of the Diagram Editor elements
+- `distribute` - forms a group of service elements for distributing the Diagram Editor elements
 
     <details>
     The `distribute` item has the following structure:
@@ -416,7 +416,7 @@ const editor = new dhx.DiagramEditor("editor_container", {
         toolbar: {
             items: [
                 {
-                    type: "button", 
+                    type: "button",
                     value: "Best button"
                 }
             ]

--- a/docs/guides/event_handling.md
+++ b/docs/guides/event_handling.md
@@ -19,21 +19,21 @@ diagram.events.on("ShapeClick", (id) => {
 });
 ~~~
 
-You can attach several handlers to the same event and all of them will be executed. If some of handlers return *false*, the related operations will be blocked. Event handlers are processed in the same order that they are attached.
+You can attach several handlers to the same event and all of them will be executed. If some of the handlers return *false*, the related operations will be blocked. Event handlers are processed in the same order that they are attached.
 
 ## Detaching event listeners
 
-To detach events, use `diagram.events.detach()` method:
+To detach events, use the `diagram.events.detach()` method:
 
 ~~~jsx
 diagram.events.on("CustomEvent", args);
- 
+
 diagram.events.detach("CustomEvent");
 ~~~
 
 ## Calling events
 
-To call events, use the `diagram.events.fire()`.
+To call events, use the `diagram.events.fire()` method.
 
 ~~~jsx
 diagram.events.fire("CustomEvent", args);
@@ -46,7 +46,7 @@ Normally, events are called automatically and you don't need to use this method.
 
 ### Diagram events
 
-Check the full list of the Diagram API events in the [API reference](api/diagram/api_overview.md#diagram-events). 
+Check the full list of the Diagram API events in the [API reference](api/diagram/api_overview.md#diagram-events).
 
 ### Editor events
 
@@ -67,11 +67,11 @@ editor.diagram.events.on("ShapeClick", (id) => {
 });
 ~~~
 
-This way can be also used if you need to apply the events which are listed below.
+This way can also be used if you need to apply the events which are listed below.
 
 ### CellManager events
 
-Check the full list of the CellManager API events in the [API Reference](/api/cell_manager/#events). 
+Check the full list of the CellManager API events in the [API Reference](/api/cell_manager/#events).
 
 ### DataCollection events
 

--- a/docs/guides/inline_editing.md
+++ b/docs/guides/inline_editing.md
@@ -1,5 +1,5 @@
 ---
-sidebar_label: Inline editing 
+sidebar_label: Inline editing
 title: Inline Editing
 description: You can learn about inline editing in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Diagram.
 ---
@@ -12,11 +12,11 @@ Inline editing for Lines is enabled only in the default mode of Diagram.
 
 ![](/img/inline_editing.gif)
 
-:::note 
+:::note
 Inline editing does not work for custom shapes.
 :::
 
-The functionality is enabled by default. To disable inline editing, you should use the `editable` property of the element, which you want to make uneditable, and set its value to *false*.
+The functionality is enabled by default. To disable inline editing, set the `editable` property of the element you want to make uneditable to *false*.
 
 You can find examples of disabling inline editing for diagram items below:
 
@@ -35,10 +35,10 @@ const data = [
         "to": "shape_2"
     },
     // configuring a line title
-    {   
-        "id": "title_1", 
+    {
+        "id": "title_1",
         "type": "lineTitle",
-        "parent": "line_1", 
+        "parent": "line_1",
         "text": "Some text",
         "editable": false // disables inline editing of the text item of a line
     }
@@ -56,7 +56,7 @@ const data = [
 #### Groups
 
 ~~~jsx title="Disabling the ability to edit the text content of the header of a group"
-const data = [    
+const data = [
     {
         "type": "$group",
         "id": 1,
@@ -84,7 +84,7 @@ const data = [
         "header": {
             "closable": true,
             "text": "Waterfall diagram template",
-            // disables inline editing for the header 
+            // disables inline editing for the header
             "editable": false
         },
         "layout": [

--- a/docs/guides/integrations/angular_integration.md
+++ b/docs/guides/integrations/angular_integration.md
@@ -25,7 +25,7 @@ ng new my-angular-diagram-app
 ~~~
 
 :::note
-If you want to follow this guide, disable Server-Side Rendering (SSR) and Static Site Generation (SSG/Prerendering) when creating new Angular app!
+If you want to follow this guide, disable Server-Side Rendering (SSR) and Static Site Generation (SSG/Prerendering) when creating a new Angular app!
 :::
 
 The command above installs all the necessary tools, so you don't need to run any additional commands.
@@ -53,11 +53,11 @@ Now you should get the DHTMLX Diagram Editor source code. First of all, stop the
 
 ### Step 1. Package installation
 
-Download the [**trial Diagram package**](guides/diagram_editor/initialization.md#installing-diagram-editor-via-npm-or-yarn) and follow steps mentioned in the README file. Note that trial Diagram Editor is available 30 days only.
-  
+Download the [**trial Diagram package**](guides/diagram_editor/initialization.md#installing-diagram-editor-via-npm-or-yarn) and follow the steps mentioned in the README file. Note that the trial Diagram Editor is available for 30 days only.
+
 ### Step 2. Component creation
 
-Now you need to create an Angular component, to add Diagram Editor into the application. Create  the **diagram-editor** folder in the **src/app/** directory, add a new file into it and name it **diagram-editor.component.ts**. Then complete the steps described below.
+Now you need to create an Angular component to add Diagram Editor into the application. Create the **diagram-editor** folder in the **src/app/** directory, add a new file into it and name it **diagram-editor.component.ts**. Then complete the steps described below.
 
 #### Import source files
 
@@ -173,7 +173,7 @@ import { Component, ElementRef, OnInit, ViewChild, OnDestroy, ViewEncapsulation 
 
 @Component({
     encapsulation: ViewEncapsulation.None,
-    selector: 'diagram-editor', 
+    selector: 'diagram-editor',
     styleUrls: ['./diagram-editor.component.css'],
     template: `<div #container class = "widget"></div>`
 })
@@ -186,7 +186,7 @@ export class DiagramEditorComponent implements OnInit, OnDestroy {
     ngOnInit() {
         const data = getData(); // initialize data property
         this._diagram_editor = new DiagramEditor( this.editor_container.nativeElement, { type: "default" } as IDefaultEditorConfig);
-        
+
         this._diagram_editor.parse(data);
     }
 
@@ -196,7 +196,7 @@ export class DiagramEditorComponent implements OnInit, OnDestroy {
 }
 ~~~
 
-Now the Diagram Editor component is ready to use. When the element will be added to the page, it will initialize the Diagram Editor with data. You can provide necessary configuration settings as well. Visit our [Diagram Editor API docs](/category/diagram-editor-api/) to check the full list of available properties.
+Now the Diagram Editor component is ready to use. When the element is added to the page, it will initialize the Diagram Editor with data. You can provide necessary configuration settings as well. Visit our [Diagram Editor API docs](/category/diagram-editor-api/) to check the full list of available properties.
 
 #### Handling events
 
@@ -228,7 +228,7 @@ import { Component } from "@angular/core";
 
 @Component({
     selector: "app-root",
-    template: `<diagram-editor/>` // a template created in the "diagram-editor.component.ts" file 
+    template: `<diagram-editor/>` // a template created in the "diagram-editor.component.ts" file
 })
 export class AppComponent {
     name = "";
@@ -266,4 +266,4 @@ After that, you can start the app to see Diagram Editor loaded with data on a pa
 
 ![Diagram Editor initialization](/img/trial_diagram.png)
 
-Now you know how to integrate DHTMLX Diagram Editor with Angular. You can customize the code according to your specific requirements. The final example you can find on [**GitHub**](https://github.com/DHTMLX/angular-diagram-demo).
+Now you know how to integrate DHTMLX Diagram Editor with Angular. You can customize the code according to your specific requirements. You can find the final example on [**GitHub**](https://github.com/DHTMLX/angular-diagram-demo).

--- a/docs/guides/integrations/react_integration.md
+++ b/docs/guides/integrations/react_integration.md
@@ -18,7 +18,7 @@ DHTMLX Diagram Editor is compatible with **React**. We have prepared code exampl
 Before you start to create a new project, install [**Vite**](https://vite.dev/) (optional) and [**Node.js**](https://nodejs.org/en/).
 :::
 
-You can create a basic **React** project (this project) or use **React with Vite**. Let's name the project as **my-react-diagram-app**:
+You can create a basic **React** project (this project) or use **React with Vite**. Let's name the project **my-react-diagram-app**:
 
 ~~~json
 npx create-react-app my-react-diagram-app
@@ -26,7 +26,7 @@ npx create-react-app my-react-diagram-app
 
 ### Installation of dependencies
 
-Go to the new created app directory:
+Go to the newly created app directory:
 
 ~~~json
 cd my-react-diagram-app
@@ -56,7 +56,7 @@ Now you should get the DHTMLX Diagram Editor source code. First of all, stop the
 
 ### Step 1. Package installation
 
-Download the [**trial Diagram Editor package**](guides/diagram_editor/initialization.md#installing-diagram-editor-via-npm-or-yarn) and follow steps mentioned in the README file. Note that trial Diagram Editor is available 30 days only.
+Download the [**trial Diagram Editor package**](guides/diagram_editor/initialization.md#installing-diagram-editor-via-npm-or-yarn) and follow the steps mentioned in the README file. Note that the trial Diagram Editor is available for 30 days only.
 
 ### Step 2. Component creation
 
@@ -101,7 +101,7 @@ export default function DiagramEditorComponent(props) {
         const diagram_editor = new DiagramEditor(container.current, {});
 
         return () => {
-            diagram_editor.destructor(); // destruct Diagram Editor 
+            diagram_editor.destructor(); // destruct Diagram Editor
         }
     });
 
@@ -160,7 +160,7 @@ export function getData() {
 }
 ~~~
 
-Then open the ***App.js*** file and import data. After this you can pass data into the new created `<DiagramEditor/>` components as `props`:
+Then open the ***App.js*** file and import data. After this, you can pass data into the newly created `<DiagramEditor/>` components as `props`:
 
 ~~~jsx {2,5-6} title="App.js"
 import DiagramEditor from "./DiagramEditor";
@@ -186,7 +186,7 @@ export default function DiagramEditorComponent(props) {
 
     useEffect(() => {
         const diagram_editor = new DiagramEditor(container.current, {});
-        
+
         diagram_editor.parse(props.data);
 
         return () => {
@@ -198,7 +198,7 @@ export default function DiagramEditorComponent(props) {
 }
 ~~~
 
-Now the Diagram Editor component is ready to use. When the element will be added to the page, it will initialize the Diagram Editor with data. You can provide necessary configuration settings as well. Visit our [Diagram Editor API docs](/category/diagram-editor-api/) to check the full list of available properties.
+Now the Diagram Editor component is ready to use. When the element is added to the page, it will initialize the Diagram Editor with data. You can provide necessary configuration settings as well. Visit our [Diagram Editor API docs](/category/diagram-editor-api/) to check the full list of available properties.
 
 #### Handling events
 
@@ -226,4 +226,4 @@ After that, you can start the app to see Diagram Editor loaded with data on a pa
 
 ![Diagram Editor initialization](/img/trial_diagram.png)
 
-Now you know how to integrate DHTMLX Diagram Editor with React. You can customize the code according to your specific requirements. The final example you can find on [**GitHub**](https://github.com/DHTMLX/react-diagram-demo).
+Now you know how to integrate DHTMLX Diagram Editor with React. You can customize the code according to your specific requirements. You can find the final example on [**GitHub**](https://github.com/DHTMLX/react-diagram-demo).

--- a/docs/guides/integrations/svelte_integration.md
+++ b/docs/guides/integrations/svelte_integration.md
@@ -24,7 +24,7 @@ To create a **Svelte** JS project, run the following command:
 npm create vite@latest
 ~~~
 
-Select Svelte and JavaScript options while creating the project. Let's name the project as **my-svelte-diagram-app**.
+Select Svelte and JavaScript options while creating the project. Let's name the project **my-svelte-diagram-app**.
 
 ### Installation of dependencies
 
@@ -34,7 +34,7 @@ Go to the app directory:
 cd my-svelte-diagram-app
 ~~~
 
-Then you need to install dependencies and run the app. For this, you need to make use of a package manager:
+Then you need to install dependencies and run the app. For this, you need to use a package manager:
 
 - if you use [**yarn**](https://yarnpkg.com/), you need to call the following commands:
 
@@ -58,11 +58,11 @@ Now you should get the DHTMLX Diagram Editor source code. First of all, stop the
 
 ### Step 1. Package installation
 
-Download the [**trial Diagram Editor package**](guides/diagram_editor/initialization.md#installing-diagram-editor-via-npm-or-yarn) and follow steps mentioned in the README file. Note that trial Diagram Editor is available 30 days only.
+Download the [**trial Diagram Editor package**](guides/diagram_editor/initialization.md#installing-diagram-editor-via-npm-or-yarn) and follow the steps mentioned in the README file. Note that the trial Diagram Editor is available for 30 days only.
 
 ### Step 2. Component creation
 
-Now you need to create a Svelte component, to add Diagram Editor into the application. Let's create a new file in the ***src/*** directory and name it ***DiagramEditor.svelte***.
+Now you need to create a Svelte component to add Diagram Editor into the application. Let's create a new file in the ***src/*** directory and name it ***DiagramEditor.svelte***.
 
 #### Importing source files
 
@@ -102,7 +102,7 @@ To display Diagram Editor on the page, you need to create the container for Diag
 
     let container; // initialize container for Diagram Editor
     let diagram_editor;
-    
+
     onMount(() => {
         // initialize the Diagram Editor component
         diagram_editor = new DiagramEditor(container, {});
@@ -187,12 +187,12 @@ Go to the ***DiagramEditor.svelte*** file and apply the passed `props` to the Di
     import { onMount, onDestroy } from "svelte";
     import { DiagramEditor } from "@dhx/trial-diagram";
     import "@dhx/trial-diagram/codebase/diagram.min.css"
-    
+
     export let data;
 
     let container;
     let diagram_editor;
-    
+
     onMount(() => {
         diagram_editor = new DiagramEditor(container, {});
         diagram_editor.parse(data);
@@ -206,7 +206,7 @@ Go to the ***DiagramEditor.svelte*** file and apply the passed `props` to the Di
 <div bind:this={container} class="widget"></div>
 ~~~
 
-Now the Diagram Editor component is ready to use. When the element will be added to the page, it will initialize the Diagram Editor with data. You can provide necessary configuration settings as well. Visit our [Diagram Editor API docs](/category/diagram-editor-api/) to check the full list of available properties.
+Now the Diagram Editor component is ready to use. When the element is added to the page, it will initialize the Diagram Editor with data. You can provide necessary configuration settings as well. Visit our [Diagram Editor API docs](/category/diagram-editor-api/) to check the full list of available properties.
 
 #### Handling events
 
@@ -240,4 +240,4 @@ After that, when we start the app, we should see Diagram Editor loaded with data
 
 ![Diagram Editor initialization](/img/trial_diagram.png)
 
-Now you should have a basic setup for integrating DHTMLX Diagram Editor with Svelte. You can customize the code according to your specific requirements. The final example you can find on [**GitHub**](https://github.com/DHTMLX/svelte-diagram-demo).
+Now you should have a basic setup for integrating DHTMLX Diagram Editor with Svelte. You can customize the code according to your specific requirements. You can find the final example on [**GitHub**](https://github.com/DHTMLX/svelte-diagram-demo).

--- a/docs/guides/integrations/vue_integration.md
+++ b/docs/guides/integrations/vue_integration.md
@@ -26,7 +26,7 @@ npm create vue@latest
 
 This command installs and executes `create-vue`, the official **Vue** project scaffolding tool. Check the details in the [Vue.js Quick Start](https://vuejs.org/guide/quick-start.html#creating-a-vue-application).
 
-Let's name the project as **my-vue-diagram-app**.
+Let's name the project **my-vue-diagram-app**.
 
 ### Installation of dependencies
 
@@ -60,11 +60,11 @@ Now you should get the DHTMLX Diagram Editor source code. First of all, stop the
 
 ### Step 1. Package installation
 
-Download the [**trial Diagram Editor package**](guides/diagram_editor/initialization.md#installing-diagram-editor-via-npm-or-yarn) and follow steps mentioned in the README file. Note that trial Diagram Editor is available 30 days only.
+Download the [**trial Diagram Editor package**](guides/diagram_editor/initialization.md#installing-diagram-editor-via-npm-or-yarn) and follow the steps mentioned in the README file. Note that the trial Diagram Editor is available for 30 days only.
 
 ### Step 2. Component creation
 
-Now you need to create a Vue component, to add Diagram Editor into the application. Create a new file in the ***src/components/*** directory and name it ***DiagramEditor.vue***.
+Now you need to create a Vue component to add Diagram Editor into the application. Create a new file in the ***src/components/*** directory and name it ***DiagramEditor.vue***.
 
 #### Import source files
 
@@ -169,7 +169,7 @@ export function getData() {
 }
 ~~~
 
-Then open the ***App.vue*** file, import data, and initialize it via the inner `data()` method. After this you can pass data into the new created `<DiagramEditor/>` component as `props`:
+Then open the ***App.vue*** file, import data, and initialize it via the inner `data()` method. After this, you can pass data into the newly created `<DiagramEditor/>` component as `props`:
 
 ~~~html {3,7-9,14} title="App.vue"
 <script>
@@ -216,7 +216,7 @@ export default {
 </template>
 ~~~
 
-Now the Diagram Editor component is ready to use. When the element will be added to the page, it will initialize the Diagram Editor with data. You can provide necessary configuration settings as well. Visit our [Diagram Editor API docs](/category/diagram-editor-api/) to check the full list of available properties.
+Now the Diagram Editor component is ready to use. When the element is added to the page, it will initialize the Diagram Editor with data. You can provide necessary configuration settings as well. Visit our [Diagram Editor API docs](/category/diagram-editor-api/) to check the full list of available properties.
 
 #### Handling events
 
@@ -237,7 +237,7 @@ export default {
         });
     }
     //...
-}   
+}
 </script>
 
 //...
@@ -247,4 +247,4 @@ After that, you can start the app to see Diagram Editor loaded with data on a pa
 
 ![Diagram Editor initialization](/img/trial_diagram.png)
 
-Now you know how to integrate DHTMLX Diagram Editor with Vue. You can customize the code according to your specific requirements. The final example you can find on [**GitHub**](https://github.com/DHTMLX/vue-diagram-demo).
+Now you know how to integrate DHTMLX Diagram Editor with Vue. You can customize the code according to your specific requirements. You can find the final example on [**GitHub**](https://github.com/DHTMLX/vue-diagram-demo).

--- a/docs/guides/items_index.md
+++ b/docs/guides/items_index.md
@@ -6,14 +6,14 @@ description: You can learn about diagram items in the documentation of the DHTML
 
 # Diagram items
 
-The next guides introduce you to all available types of Diagram items, and discuss peculiarities on their configuration.
+The following guides introduce all available types of Diagram items and discuss the specifics of their configuration.
 
 import DocCardList from '@theme/DocCardList';
 import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
 <DocCardList items={useCurrentSidebarCategory().items}/>
 
-After you have learnt the guides, you can check the following API sections to accelerate the development process:
+After you have read the guides, you can check the following API sections to accelerate the development process:
 
 - [Items API properties](category/items-api.md)
 - [DataCollection API](/api/data_collection/) (allows adding, removing, filtering data items (such as shapes, lines, line titles, groups, swimlanes), etc.)
@@ -22,7 +22,7 @@ After you have learnt the guides, you can check the following API sections to ac
 - [Diagram API](api/diagram/api_overview.md)
 - [Diagram Editor API](api/diagram_editor/editor/api_overview.md)
 
-To get more knowledge on how to load, customize, edit items and perform different operations over them, read the guides:
+To learn how to load, customize, and edit items and perform various operations on them, read the guides:
 
 - [Loading and storing data](guides/loading_data.md)
 - [Customizing items](guides/customization.md)

--- a/docs/guides/loading_data.md
+++ b/docs/guides/loading_data.md
@@ -1,5 +1,5 @@
 ---
-sidebar_label: Loading and storing data 
+sidebar_label: Loading and storing data
 title: Loading and Storing data
 description: You can learn about loading and storing data of editor in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Diagram.
 ---
@@ -31,9 +31,9 @@ const data = [
 ];
 ~~~
 
-The library provides you with [various types of default shapes](shapes/default_shapes.md) which have both common and specific options. Check the full list of available properties of a `shape` object in the [API reference](shapes/configuration_properties.md). 
+The library provides you with [various types of default shapes](shapes/default_shapes.md) which have both common and specific options. Check the full list of available properties of a `shape` object in the [API reference](shapes/configuration_properties.md).
 
-Besides, you may create [your own type of shapes](shapes/custom_shape.md) and add any custom properties to shape objects.
+You can also create [your own type of shapes](shapes/custom_shape.md) and add any custom properties to shape objects.
 
 - **line objects**
 
@@ -74,7 +74,7 @@ Check the full list of available properties of the **line title** object in the 
 - **group objects**
 
 ~~~jsx
-const data = [    
+const data = [
     {
         "type": "$group",
         "id": 1,
@@ -160,11 +160,11 @@ Check the full list of the available configuration properties of the objects of 
 
 ## Working with Diagram data in the PERT mode
 
-There are the following peculiarities of working with Diagram in the PERT mode: 
+Working with Diagram in the PERT mode has the following peculiarities:
 
 - the [data loaded into the Diagram](#data-structure-of-diagram-in-the-pert-mode) has the structure of DHTMLX Gantt data
 - while working with data in the Diagram, it is processed via [Data Collection](/api/data_collection/) the same as data in other Diagram modes
-- the [exported Diagram data](#saving-and-restoring-state) has the structure of DHTMLX Gantt data 
+- the [exported Diagram data](#saving-and-restoring-state) has the structure of DHTMLX Gantt data
 
 ### Data structure of Diagram in the PERT mode
 
@@ -179,7 +179,7 @@ The structure of Diagram data in the PERT mode coincides with the [data structur
 
 Such a structure allows processing the shapes and their connections independently. [Check important notes on working with links](#processing-links).
 
-There are the following types of shapes and connections specific for the Diagram in the PERT mode:
+The Diagram in the PERT mode supports the following types of shapes and connections:
 
 - **project objects**
 
@@ -290,7 +290,7 @@ For example:
 }
 
 // diagram.data.getItem("$link:1");
-~~~ 
+~~~
 :::
 
 ### Specificity of data loading in the PERT mode
@@ -298,19 +298,19 @@ For example:
 Follow the recommendations below to avoid errors and render Diagram in a correct way:
 
 - **Absence of cyclic dependencies**. There is no support for cycles among tasks, projects, links and mixed elements. In case a cyclic dependency is detected, an exception will appear.
-- **Links between the parent and children are permitted**. Direct connections between the parent element (e.g. a project) and its children elements are not allowed. Such connections will be deleted automatically during data processing.
-- **Avoid intersecting connections**. Reduce the number of intersecting links to the minimum, as they may make the diagram more complex and lead to the low-level readability. 
-- **Successive data processing**. Data are processed in the order they are coming, which may affect the arrangement of elements. You should specify the data in the logical order to achieve the best result.
+- **Links between the parent and children are not permitted**. Direct connections between the parent element (e.g. a project) and its child elements are not allowed. Such connections will be deleted automatically during data processing.
+- **Avoid intersecting connections**. Reduce the number of intersecting links to the minimum, as they may make the diagram more complex and reduce its readability.
+- **Successive data processing**. Data are processed in the order they arrive, which may affect the arrangement of elements. You should specify the data in a logical order to achieve the best result.
 - **Task sequencing**. Use linear or sequential connections between tasks and projects to keep the diagram clear and avoid visual disorder.
 
-The above rules are intended for creating clean, non-cyclic graphs, suitable for PERT analysis. If data break these rules, Diagram may automatically correct them (for example, by removing unacceptable connections). However, it is better to check the data input beforehand.   
+The above rules are intended for creating clean, non-cyclic graphs, suitable for PERT analysis. If data break these rules, Diagram may automatically correct them (for example, by removing unacceptable connections). However, it is better to check the data input beforehand.
 
 ### Rendering Gantt tasks with not connected children in the Diagram
 
-Note that the Gantt elements with `type: "task"` may have children elements not connected to the parent task visually. Such relations won't be reflected in the Diagram. For such elements to be rendered in the same project visually, you can:
+Note that the Gantt elements with `type: "task"` may have child elements not connected to the parent task visually. Such relations won't be reflected in the Diagram. For such elements to be rendered in the same project visually, you can:
 
 - either assign `type:"project"` to the parent element on loading data into Diagram
-- or assign the *parent project* id of such a task to its children elements
+- or assign the *parent project* id of such a task to its child elements
 
 For example:
 
@@ -318,8 +318,8 @@ For example:
 {
     data: [
         { id: "1", type: "project" },
-        { id: "1.1", type: "task", parent: "1" }, 
-        { id: "1.1.1", type: "task", parent: "1.1" } 
+        { id: "1.1", type: "task", parent: "1" },
+        { id: "1.1.1", type: "task", parent: "1.1" }
     ]
 }
 ~~~
@@ -333,7 +333,7 @@ In the above example:
     ~~~jsx
     { id: "1.1.1", type: "task", parent: "1" }
     ~~~
-    - or use the `"project"` type instead of the `"task"` type for the parent element "1.1": 
+    - or use the `"project"` type instead of the `"task"` type for the parent element "1.1":
     ~~~jsx
      { id: "1.1", type: "project", parent: "1" }
     ~~~
@@ -383,13 +383,13 @@ editor.parse(data);
 To save the current state of a diagram, use the [`serialize()`](api/data_collection/serialize_method.md) method. Depending on the Diagram mode, it converts the data of the diagram into:
 
 - for the default, org chart and mindmap Diagram modes - into an array of objects, where each object contains the configuration of a separate shape
-- for the PERT Diagram mode - into an object with the `data` array of objects (for shapes: `"task"`, `"milestone"`, `"project"`) and the `links` array of objects (for connections between shapes). 
+- for the PERT Diagram mode - into an object with the `data` array of objects (for shapes: `"task"`, `"milestone"`, `"project"`) and the `links` array of objects (for connections between shapes).
 
 ~~~jsx
 const state = diagram1.data.serialize();
 ~~~
 
-Note that the for PERT Diagram mode the *links* objects in the exported data object will have [the same types as in the DHTMLX Gantt chart](https://docs.dhtmlx.com/gantt/desktop__link_properties.html). It means that if the type of a link in the Diagram data coincides with some of the Gantt links types, it will remain the same during serialization. If the link type isn't specified or set differently (for example, `type: "line"`), it will be converted into `type: "0"`.
+Note that for the PERT Diagram mode, the *links* objects in the exported data object will have [the same types as in the DHTMLX Gantt chart](https://docs.dhtmlx.com/gantt/desktop__link_properties.html). It means that if the type of a link in the Diagram data coincides with some of the Gantt links types, it will remain the same during serialization. If the link type isn't specified or set differently (for example, `type: "line"`), it will be converted into `type: "0"`.
 
 Then you can parse the data stored in the saved state to a different diagram. For example:
 

--- a/docs/guides/localization.md
+++ b/docs/guides/localization.md
@@ -6,7 +6,7 @@ description: You can learn about the Localization in the documentation of the DH
 
 # Localization
 
-It is possible to localize the interface of the Diagram editor into a desired language. For this, you need to provide the corresponding locale settings via the `dhx.i18n.setLocale()` method.
+You can localize the interface of the Diagram editor into any language. For this, you need to provide the corresponding locale settings via the `dhx.i18n.setLocale()` method.
 The method takes two parameters: the diagram container and an object that contains rules of localization for a particular country.
 
 ~~~jsx

--- a/docs/guides/manipulating_items.md
+++ b/docs/guides/manipulating_items.md
@@ -1,21 +1,21 @@
 ---
-sidebar_label: Manipulating items 
+sidebar_label: Manipulating items
 title: Manipulating Items
 description: You can learn about manipulating items in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Diagram.
 ---
 # Manipulating items
 
-You can easily manipulate Diagram items via the [Diagram Editor](guides/diagram_editor/initialization.md). But in this article we'll explore the examples on how to manipulate the items of DHTMLX Diagram via the component's API. 
+You can manipulate Diagram items via the [Diagram Editor](guides/diagram_editor/initialization.md). This article explores how to manipulate the items of DHTMLX Diagram via the component's API.
 
 ## Overview
 
-The article contains different sections that cover such questions as:
+This article contains sections that cover the following:
 
 - [how to automatically arrange shapes in the hierarchical order](#arranging-shapes-automatically);
-- how to perform a range of operations over items, in particular:
+- how to perform a range of operations on items, in particular:
     - [add](#adding-an-item)/[update](#updating-an-item)/[delete](#deleting-items) items;
     - [check if an item exists](#checking-existence-of-the-item) in the diagram and [get it](#getting-an-item);
-    - [select a certain item](#selecting-items);
+    - [select an item](#selecting-items);
     - [scroll to a necessary item](#showing-the-necessary-item) to make it visible on the screen, if there are many items in the diagram;
     - [expand/collapse items](#expandingcollapsing-items);
     - [find items](#finding-the-necessary-item) that meet some criteria;
@@ -34,7 +34,7 @@ The library provides you with the ability to implement auto-placement for shapes
 - to place connected shapes in the symmetric order at once;
 - to arrange data loaded in the JSON format or loaded from the server in the hierarchical structure.
 
-To perform the auto-placement, you need to make use of the [`autoPlace()`](api/diagram/autoplace_method.md) method. The method can take one parameter:
+To perform the auto-placement, use the [`autoPlace()`](api/diagram/autoplace_method.md) method. The method can take one parameter:
 
 - `config` - (*object*) optional, an object with configuration settings of the auto-placement. The object can contain the following properties:
     - `mode` - (*string*) optional, the mode of connecting shapes, `"direct"` (by default) or `"edges"`
@@ -62,7 +62,7 @@ diagram.autoPlace({
 
 **Related sample**: [Diagram. Default mode. Autoplacement](https://snippet.dhtmlx.com/f3uekgjw)
 
-In case you don't pass the parameter to the method, the default settings will be applied.
+If you don't pass the parameter to the method, the default settings will be applied.
 
 ~~~jsx
 const diagram = new dhx.Diagram("diagram_container");
@@ -78,7 +78,7 @@ const diagram = new dhx.Diagram("diagram_container", {
     scale: 0.3,
     autoplacement: {
         placeMode: "radial",
-        mode: "direct" 
+        mode: "direct"
     }
 });
 
@@ -100,7 +100,7 @@ diagram.autoPlace({
 To add a new item into a diagram, apply the [`add()`](api/data_collection/add_method.md) method of the `data` object.
 
 ~~~jsx
-diagram.data.add({ id: "3.2", text: "New Item", parent: "3" }); 
+diagram.data.add({ id: "3.2", text: "New Item", parent: "3" });
 ~~~
 
 For example, we've added a new shape object that has the following attributes:
@@ -121,14 +121,14 @@ You can get the object of an item by passing its id to the [`getItem()`](api/dat
 const shape = diagram.data.getItem(1);
 ~~~
 
-After getting an item, you can access its original properties, as follows: 
+After getting an item, you can access its original properties, as follows:
 
 ~~~jsx
 const shape = diagram.data.getItem(1);
 const text = shape.text;
 ~~~
 
-## Getting the id of an item 
+## Getting the id of an item
 
 If the id of an item is unknown, you can use the [`getId()`](api/data_collection/getid_method.md) method to get it. The method takes the index of the item as a parameter:
 
@@ -148,10 +148,10 @@ const id = diagram.data.getIndex("1"); // -> returns 0
 
 ### Deleting a single item
 
-To delete an unnecessary item, make use of the [`remove()`](api/data_collection/remove_method.md) method of the `data` object and pass as a parameter the id of the item under question:
+To delete an unnecessary item, use the [`remove()`](api/data_collection/remove_method.md) method of the `data` object and pass the id of the item in question as a parameter:
 
 ~~~jsx
-diagram.data.remove("3.2");  
+diagram.data.remove("3.2");
 ~~~
 
 :::note
@@ -178,7 +178,7 @@ diagram.data.update("1", { text: "Some new text" });
 
 As parameters, you need to pass two parameters:
 
-- `id` - (*string|number*) the id of the item 
+- `id` - (*string|number*) the id of the item
 - `config` - (*object*) an object with updated configuration properties
 
 **Related sample**: [Diagram. Data. Update item](https://snippet.dhtmlx.com/y8uk4sbj)
@@ -195,12 +195,12 @@ const shapeExists = diagram.data.exists("1");
 
 ### Selecting an item
 
-To select items, you need firstly [enable selection](guides/diagram/configuration.md#enabling-items-selection) for the diagram and then call the [add()](api/selection/add_method.md) method of the `selection` object to select a desired item.
+To select items, you first need to [enable selection](guides/diagram/configuration.md#enabling-items-selection) for the diagram and then call the [add()](api/selection/add_method.md) method of the `selection` object to select a desired item.
 
 ~~~jsx {8,11-12,15-16}
 // a diagram must be created with the "select:true" option
-const diagram = new dhx.Diagram("diagram_container", { 
-    select: true 
+const diagram = new dhx.Diagram("diagram_container", {
+    select: true
 });
 // loading data
 diagram.data.parse(data);
@@ -209,11 +209,11 @@ diagram.selection.add({ id: "1" }); // -> returns true if the item has been sele
 console.log(diagram.selection.getIds()); // -> ["1"]
 
 // adds the item with the id:"2" to the already selected items
-diagram.selection.add({ id: "2", join: true }); 
+diagram.selection.add({ id: "2", join: true });
 console.log(diagram.selection.getIds()); // -> ["1", "2"]
 
 // removes the previously selected items and adds the item with the id:"3"
-diagram.selection.add({ id: "3" }); 
+diagram.selection.add({ id: "3" });
 console.log(diagram.selection.getIds()); // -> ["3"]
 ~~~
 
@@ -226,11 +226,11 @@ The method takes as an argument an object with the following parameters:
 The method returns:
 
 - `true` if the element hadn't been in the list and was successfully added into it
-- `false` if the element wasn't added into the list by some reason, e.g. an element had already been added to the list
+- `false` if the element wasn't added into the list for some reason, e.g. an element had already been added to the list
 
 ### Unselecting an item
 
-To remove an item from the selection list, make use of the [`remove()`](api/selection/remove_method.md) method of the `selection` object:
+To remove an item from the selection list, use the [`remove()`](api/selection/remove_method.md) method of the `selection` object:
 
 ~~~jsx {2}
 console.log(diagram.selection.getIds()); // -> ["1", "2", "3"]
@@ -238,14 +238,14 @@ diagram.selection.remove({ id: "3" }); // -> returns true if the item has been u
 console.log(diagram.selection.getIds()); // -> ["1", "2"]
 ~~~
 
-The method may take an object with *the id of the item to unselect* as a parameter. It returns *true*, if the item has been successfully removed from the selection list. 
+The method may take an object with *the id of the item to unselect* as a parameter. It returns *true*, if the item has been successfully removed from the selection list.
 
 You can also call the method with no arguments to clear the selection list as follows:
 
 ~~~jsx {2-3}
 console.log(diagram.selection.getIds()); // -> ["1", "2", "3"]
 // removes all the items from the selection list
-diagram.selection.remove(); 
+diagram.selection.remove();
 console.log(diagram.selection.getIds()); // -> []
 ~~~
 
@@ -267,25 +267,25 @@ You can get the object of a selected item using the [`getItem()`](api/selection/
 
 You can also call the method without the parameter to get the object of the last selected item. Check the examples below to explore the method's functionality:
 
-~~~jsx {9-11,13-15,17-19} 
+~~~jsx {9-11,13-15,17-19}
 // a diagram must be created with the "select:true" option
-const diagram = new dhx.Diagram("diagram_container", { 
-    select: true 
+const diagram = new dhx.Diagram("diagram_container", {
+    select: true
 });
 // loading data
 diagram.data.parse(data);
 
 console.log(diagram.selection.getIds()); // -> ["1", "2", "3"]
 // getting the last selected item
-const item = diagram.selection.getItem(); 
+const item = diagram.selection.getItem();
 // -> {id: "3", text: "Technical Director", title: "Jerry Wagner"}
 
 // getting the selected item by id
-const item = diagram.selection.getItem({ id: "1" }); 
+const item = diagram.selection.getItem({ id: "1" });
 // -> {id: "1", text: "Chairman & CEO", title: "Henry Bennett"}
 
 // trying to get an item which is not in the selection list
-const item = diagram.selection.getItem({ id: "4" }); 
+const item = diagram.selection.getItem({ id: "4" });
 // -> returns undefined, since there is no item with the specified id in the selection list
 ~~~
 
@@ -315,9 +315,9 @@ The method takes as an argument an object with the following parameters:
 
 ## Expanding/collapsing items
 
-You can expand and collapse either a shape that have child shapes or a group/swimlane via the corresponding API methods: [expandItem()](api/diagram/expanditem_method.md) and [collapseItem()](api/diagram/collapseitem_method.md).
+You can expand and collapse either a shape that has child shapes or a group/swimlane via the corresponding API methods: [expandItem()](api/diagram/expanditem_method.md) and [collapseItem()](api/diagram/collapseitem_method.md).
 
-Both methods takes two parameters:
+Both methods take two parameters:
 
 - `id` - (*string|number*) the id of the item
 - `dir` - (*string*) optional, defines the side the children will be hidden/shown in relation to the parent shape: `"left"`, `"right"`
@@ -331,7 +331,7 @@ diagram.collapseItem("3");
 ~~~
 
 :::note
-**Note**, that the `dir` attribute can be used only in the mindmap mode of Diagram (type:`"mindmap"`).
+The `dir` attribute can be used only in the mindmap mode of Diagram (type:`"mindmap"`).
 :::
 
 ~~~jsx
@@ -347,11 +347,11 @@ diagram.expandItem("main", "left");
 
 ## Showing the necessary item
 
-In case you have a large diagram with lots of items, DHTMLX Diagram provides you with the possibility to make the desired item visible.
-For this, you need to apply the [`showItem()`](api/diagram/showitem_method.md) method, which takes the id of an item as a parameter:
+If you have a large diagram with lots of items, you can make the desired item visible.
+For this, apply the [`showItem()`](api/diagram/showitem_method.md) method, which takes the id of an item as a parameter:
 
 ~~~jsx
-diagram.showItem("2.1");  
+diagram.showItem("2.1");
 ~~~
 
 **Related sample**: [Diagram. Scroll content](https://snippet.dhtmlx.com/f970hbym)
@@ -365,9 +365,9 @@ The method takes the search criteria as a parameter and returns the first object
 
 ~~~jsx
 // searching for a shape by the attribute key
-const shape = diagram.data.find({by:"text",match:"Manager"}); 
+const shape = diagram.data.find({by:"text",match:"Manager"});
 // ->{id:"2",text:"Manager",title:"Mildred Kim",img:"../avatar-2.png",type:"card", …}
- 
+
 // searching for a shape by the function
 const shape = diagram.data.find((shape) => {
     if(shape.text==="Manager"||shape.text==="Marketer"){
@@ -385,7 +385,7 @@ You can also find all the items that meet the set criteria via the [`findAll()`]
 ~~~jsx
 // searching for shapes by the attribute key
 const shapes = diagram.data.findAll({by:"text",match:"Manager"});
- 
+
 // searching for shapes by the function
 const shapes = diagram.data.findAll((shapes) => {
     if(shapes.text==="Manager"||shapes.text==="Marketer"){
@@ -398,7 +398,7 @@ const shapes = diagram.data.findAll((shapes) => {
 
 ## Filtering items
 
-It is possible to filter the diagram and render only the items that meet the filter criteria via the [`filter()`](api/data_collection/filter_method.md) method of the `data` collection. The method will show only the filtered items, hiding the rest of items.
+You can filter the diagram and render only the items that meet the filter criteria via the [`filter()`](api/data_collection/filter_method.md) method of the `data` collection. The method shows only the filtered items and hides the rest.
 
 <iframe src="https://snippet.dhtmlx.com/tm43bsgn?mode=result" frameborder="0" class="snippet_iframe" width="100%" height="600"></iframe>
 
@@ -406,13 +406,13 @@ It is possible to filter the diagram and render only the items that meet the fil
 
 The default settings of a group allow you to reorder child items in the group and drag items between groups.
 
-If needed you can disable dragging child items to different groups and make it possible to drag the items only within their parent group. In addition, you can adjust the behavior of the borders of the parent group and define whether they should expand when a user is dragging a child item outside the group.
+If needed, you can disable dragging child items to different groups and make it possible to drag the items only within their parent group. In addition, you can adjust the behavior of the borders of the parent group and define whether they should expand when a user is dragging a child item outside the group.
 
 For more details about how to configure the behavior of group items, read the [related article](/groups/#configuring-the-behavior-of-group-items).
 
 ## Working with swimlane cells
 
-You can manage swimlane cells with the help of the [CellManager API](/api/cell_manager/). For example, you can add, move, remove cells as rows or columns, validate cells, and much more. 
+You can manage swimlane cells with the help of the [CellManager API](/api/cell_manager/). For example, you can add, move, remove cells as rows or columns, validate cells, and much more.
 
 Let's take a swimlane of the following configuration:
 
@@ -434,7 +434,7 @@ const data = [
         },
         subHeaderRows: {
             headers:[
-                { text: "Subheader 1", id: "s1" }, 
+                { text: "Subheader 1", id: "s1" },
                 { text: "Subheader 2", id: "s2" },
                 { text: "Subheader 3", id: "s3" }
             ]
@@ -467,7 +467,7 @@ diagram.cellManager.resetSwimlane();
 
 ### Adding a column/row
 
-You can add a set of cells either as a row or column into the swimlane. For this, you should apply the [`add()`](api/cell_manager/add_method.md) method of the cellManager object and pass two parameters to the method: 
+You can add a set of cells either as a row or column into the swimlane. For this, you should apply the [`add()`](api/cell_manager/add_method.md) method of the cellManager object and pass two parameters to the method:
 - the start index of the position of the cell where a new column/row should be added;
 - the direction of its adding: *`"up"` | `"down"`* to add a row, *`"left"` | `"right"`* to add a column.
 
@@ -496,7 +496,7 @@ diagram.cellManager.remove(1, "col");
 
 ### Moving a column/row
 
-It is possible to change the position of a column or row in the swimlane by applying the [`move()`](api/cell_manager/move_method.md) method of the cellManager object. The method allows you to move a column one position right or left, or move a row one position up or down. The method takes two parameters:
+You can change the position of a column or row in the swimlane by applying the [`move()`](api/cell_manager/move_method.md) method of the cellManager object. The method allows you to move a column one position right or left, or move a row one position up or down. The method takes two parameters:
 
 - the index of the current position of the column/row to move
 - the direction of moving the item: *`"up"` | `"down"`* to move a row, *`"left"` | `"right"`* to move a column
@@ -520,7 +520,7 @@ diagram.cellManager.validation(0, "down", "move"); // true
 
 ### Getting the type of the subheader
 
-To return the type of the subheader of a swimlane, use the [`getSubHeaderType()`](api/cell_manager/getsubheadertype_method.md) method of the cellManager object. The method takes the id of a subheader as a parameter: 
+To return the type of the subheader of a swimlane, use the [`getSubHeaderType()`](api/cell_manager/getsubheadertype_method.md) method of the cellManager object. The method takes the id of a subheader as a parameter:
 
 ~~~jsx
 diagram.cellManager.getSubHeaderType("s1"); // returns "row"

--- a/docs/guides/overview.md
+++ b/docs/guides/overview.md
@@ -6,12 +6,12 @@ description: You can study JavaScript diagram guides in the documentation of the
 
 # Guides overview
 
-The guidance information explores in detail how to create a diagram of any complexity using DHTMLX Diagram.
-The documentation is segmented into task-oriented manuals which discuss the principles of building and configuring a diagram, the ways of editing its items. The guides embody a lot of tools to assist in actual use of DHTMLX Diagram: examples of usage, illustrations, animated images.
+These guides explain in detail how to create a diagram of any complexity using DHTMLX Diagram.
+The documentation is divided into task-oriented manuals that discuss the principles of building and configuring a diagram and the ways of editing its items. The guides include many aids to help you use DHTMLX Diagram: usage examples, illustrations, and animated images.
 
 ## Diagram
 
-The section details the process of adding DHTMLX Diagram on a page, describes the features of Diagram configuration, explains the way of scrolling a large diagram.
+This section details how to add DHTMLX Diagram to a page, describes Diagram configuration, and explains how to scroll a large diagram.
 
 - [How to start with Diagram](guides/diagram/initialization.md)
 - [Diagram configuration](guides/diagram/configuration.md)
@@ -19,7 +19,7 @@ The section details the process of adding DHTMLX Diagram on a page, describes th
 
 ## Diagram items
 
-The section includes descriptions for all default diagram items (shapes, lines, groups, swimlanes), the way of adding custom shapes, and teaches how to configure the items and set connections between them. 
+This section describes all default diagram items (shapes, lines, groups, swimlanes), shows how to add custom shapes, and teaches how to configure the items and set connections between them.
 
 - [Default shapes](shapes/default_shapes.md)
 - [Custom shape](shapes/custom_shape.md)
@@ -29,11 +29,11 @@ The section includes descriptions for all default diagram items (shapes, lines, 
 
 ## Diagram Editor
 
-Learn how to initialize Diagram Editor - a great tool which significantly accelerates the process of designing your diagram.
+Learn how to initialize Diagram Editor, a tool that speeds up designing your diagram.
 
 - [How to start with Diagram Editor](guides/diagram_editor/initialization.md)
 
-The guides give you a broad overview of all parts of the interface of the editor and their settings, present examples of customization of the interface elements you may have at your disposal.
+The guides give a broad overview of all parts of the editor interface and their settings, and present customization examples for the interface elements.
 
 - [Toolbar](guides/diagram_editor/toolbar.md)
 - [Shapebar](guides/diagram_editor/shapebar.md)
@@ -47,20 +47,20 @@ Read the articles to learn the ways of loading data into the Diagram, serializin
 - [Loading and storing data](guides/loading_data.md)
 - [Exporting Diagram](guides/data_export.md)
 
-With the following articles you will be able to create a fully customized diagram and breath life into it: operate the diagram and its items via the API, attach handlers to the necessary events.
+The following articles help you create a fully customized diagram: operate the diagram and its items via the API and attach handlers to the necessary events.
 
 - [Manipulating items](guides/manipulating_items.md)
 - [Customizing items](guides/customization.md)
 - [Event handling](guides/event_handling.md)
 
-Learn how to adapt the diagram to various languages and easily edit the text elements.
+Learn how to adapt the diagram to various languages and edit the text elements.
 
 - [Localization](guides/localization.md)
 - [Inline Editing](guides/inline_editing.md)
 
 ## Integration guides
 
-The articles give you examples of usage a Diagram with different client-side frameworks.
+The articles give you examples of using Diagram with different client-side frameworks.
 
 - [Integration with Angular](guides/integrations/angular_integration.md)
 - [Integration with React](guides/integrations/react_integration.md)
@@ -68,7 +68,7 @@ The articles give you examples of usage a Diagram with different client-side fra
 
 ## Touch support
 
-You can easily create responsive web applications using DHTMLX Diagram due to built-in touch support. Check out how UI widgets work on touch devices in the [Touch support](guides/touch_support.md) guide.
+You can create responsive web applications with DHTMLX Diagram thanks to built-in touch support. Check out how UI widgets work on touch devices in the [Touch support](guides/touch_support.md) guide.
 
 ## TypeScript support
 

--- a/docs/guides/themes/base_themes_configuration.md
+++ b/docs/guides/themes/base_themes_configuration.md
@@ -41,7 +41,7 @@ Color values are specified in the [HSL](https://developer.mozilla.org/en-US/docs
 - *lightness* is a percentage value; 100% is white, 0% is black, and 50% is `"normal"`.
 :::
 
-Due to the use of these CSS variables, color scheme is calculated automatically. It means, that if you change some value for the variable from the color scheme in the root, values for the `"contrast-light"`, `"dark"`, and `"contrast-dark"` themes will be recalculated automatically in real time. 
+Thanks to these CSS variables, the color scheme is calculated automatically. This means that if you change a value of a color-scheme variable in the root, values for the `"contrast-light"`, `"dark"`, and `"contrast-dark"` themes will be recalculated automatically in real time.
 
 For instance, you can override the primary colors for all Diagram themes at once in the following way:
 
@@ -64,7 +64,7 @@ In addition, values of variables, which are calculated on the base of the primar
 
 If you want to override some color values for a separate [Diagram theme](guides/themes.md), you need to do this in the `'data-dhx-theme'` attribute:
 
-~~~html 
+~~~html
 <style>
     [data-dhx-theme='light'] {
         /* border */
@@ -97,7 +97,7 @@ If you want to override some color values for a separate [Diagram theme](guides/
     const diagram = new dhx.Diagram("diagram_container", {
         type: "default",
     });
-    
+
     dhx.setTheme("light");
 </script>
 ~~~
@@ -116,7 +116,7 @@ The default values of these variables [depend on the applied theme](guides/theme
 
 ### Setting custom CSS variables
 
-It is also possible to adjust the look and feel of the Shapebar items by using your own CSS variables. For this, you should define a custom CSS variable and specify it as a value of the necessary property in the `defaults` configuration option.
+You can also adjust the look and feel of the Shapebar items by using your own CSS variables. For this, you should define a custom CSS variable and specify it as a value of the necessary property in the `defaults` configuration option.
 
 :::note
 The value of the variable will be assigned to a Shapebar item when it is selected and won't be redefined on the change of a theme.
@@ -160,12 +160,12 @@ For example:
 
 ## Adjusting the look of tasks in the PERT mode
 
-The appearance of tasks of the [Diagram in the PERT chart mode](/#diagram-in-the-pert-mode) is defined by the `--dhx-shape-pert-header-background` CSS variable. It is specified in the [default](guides/themes.md#light-theme-default) theme in the following way: 
+The appearance of tasks of the [Diagram in the PERT chart mode](/#diagram-in-the-pert-mode) is defined by the `--dhx-shape-pert-header-background` CSS variable. It is specified in the [default](guides/themes.md#light-theme-default) theme in the following way:
 
 ~~~jsx
 --dhx-shape-pert-header-background: var(--dhx-gantt-base-colors-primary, #537CFA);
 ~~~
 
 - when Diagram in the PERT chart mode is used together with DHTMLX Gantt, the current color scheme of the Gantt chart will be applied to the Diagram tasks
-- when Diagram is used standalone, the above mentioned CSS variable will be set to the default value, which is `#537CFA`
+- when Diagram is used standalone, the above-mentioned CSS variable will be set to the default value, which is `#537CFA`
 

--- a/docs/guides/themes/custom_theme.md
+++ b/docs/guides/themes/custom_theme.md
@@ -6,12 +6,12 @@ description: You can learn how to create a custom theme in the documentation of 
 
 # Custom theme
 
-If the base Diagram themes don't fit your project, you can configure your own color theme. 
+If the base Diagram themes don't fit your project, you can configure your own color theme.
 Check the **custom light** and **custom dark** themes in the snippet below:
 
 <iframe src="https://snippet.dhtmlx.com/9twmlfus?mode=result" frameborder="0" class="snippet_iframe" width="100%" height="600"></iframe>
 
-To make a custom theme of your own, you need to override the values of the internal CSS variables as follows:
+To make a custom theme, override the values of the internal CSS variables as follows:
 
 ~~~html
 <style>
@@ -71,7 +71,7 @@ To make a custom theme of your own, you need to override the values of the inter
     const diagram = new dhx.Diagram("diagram_container", {
         type: "default",
     });
-    
+
     dhx.setTheme("custom-theme-dark");
 </script>
 ~~~

--- a/docs/guides/themes/themes.md
+++ b/docs/guides/themes/themes.md
@@ -44,8 +44,8 @@ The default `"light"` theme is configured on the base of the CSS variables which
 	/* font */
 	--dhx-font-family: "Roboto", Arial, Tahoma, Verdana, sans-serif;
 
-	--dhx-font-weight-regular: 400; 
-	--dhx-font-weight-medium: 500; 
+	--dhx-font-weight-regular: 400;
+	--dhx-font-weight-medium: 500;
 	--dhx-font-weight-bold: 700;
 
 	--dhx-font-size-small: 12px;
@@ -238,7 +238,7 @@ The `"contrast-light"` theme is configured both on the base of the [root CSS var
 	--dhx-s-grid-header-background: var(--dhx-background-secondary);
 	--dhx-s-grid-selection-background: var(--dhx-color-gray-700);
 	/* end DHTMLX Grid service variables*/
-	
+
 	/* DHTMLX Calendar service variables*/
 	--dhx-s-calendar-muffled: .8;
 	/* end DHTMLX Calendar service variables*/
@@ -295,7 +295,7 @@ The `"dark"` theme is configured both on the base of the [root CSS variables](#l
 	--dhx-s-grid-header-background: #212329;
 	--dhx-s-grid-selection-background: var(--dhx-color-gray-100);
 	/* end DHTMLX Grid service variables*/
-	
+
 	/* DHTMLX Calendar service variables*/
 	--dhx-s-calendar-muffled: .6;
 	/* end DHTMLX Calendar service variables*/
@@ -416,7 +416,7 @@ The `dhx.setTheme()` method takes the following parameters:
 
 Below you'll find the examples of the `dhx.setTheme()` method usage:
 
-- applying a theme either to the body or to the container 
+- applying a theme either to the body or to the container
 
 ~~~html {8-11}
 <div id="editor_container"></div>
@@ -426,10 +426,10 @@ Below you'll find the examples of the `dhx.setTheme()` method usage:
     const editor = new dhx.DiagramEditor("editor_container", {
         type: "default"
     });
-    dhx.setTheme("dark"); //applies the "dark" theme to the body 
+    dhx.setTheme("dark"); //applies the "dark" theme to the body
     //or
     //applies the "dark" theme to the container with the "editor_container" id
-    dhx.setTheme("dark", "editor_container"); 
+    dhx.setTheme("dark", "editor_container");
 </script>
 ~~~
 

--- a/docs/guides/touch_support.md
+++ b/docs/guides/touch_support.md
@@ -8,10 +8,10 @@ description: You can learn about touch support in the documentation of the DHTML
 
 ![](/img/touch_support.png)
 
-Since version 4.2 and upper, the DHTMLX Diagram library provides the built-in Touch support that should work out of the box.
+Since version 4.2 and later, the DHTMLX Diagram library provides built-in touch support that works out of the box.
 
-While interacting with applications by touching the screen, a tap becomes the same thing as a mouse click.
-Thus, the click events (fire on clicking, double clicking an item) will continue working on touch-screen devices. But note, that the mouseover events will not trigger.
+When you interact with applications by touching the screen, a tap works the same as a mouse click.
+Thus, the click events (fire on clicking, double clicking an item) will continue working on touch-screen devices. Note that the mouseover events will not trigger.
 
 Touch support enables recognition for the following touch gestures:
 

--- a/docs/line_titles/configuration_properties.md
+++ b/docs/line_titles/configuration_properties.md
@@ -1,13 +1,13 @@
 ---
-sidebar_label: LineTitle properties 
+sidebar_label: LineTitle properties
 title: LineTitle Properties
 description: You can learn about the LineTitle properties in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Diagram.
 ---
 
 # LineTitle properties
 
-:::note 
-While specifying color values of the item, use the HEX format.
+:::note
+Specify color values in the HEX format.
 :::
 
 ### Usage
@@ -19,7 +19,7 @@ const data = [
         type: "lineTitle",
         id?: string | number,
         text: string,
-        parent: string | number, 
+        parent: string | number,
 
         distance?: number, // 50 by default
         autoPosition?: boolean, // true by default
@@ -51,7 +51,7 @@ Each line title object can include the following properties:
 - `autoPosition` - (optional) defines the direction of the text, if set to *true* - the direction of the text is the same as that of the line, *false* - the direction of the text is always horizontal, *true* by default
 - `editable` - (optional) enables/disables the ability to edit the text of the item by double-clicking on it, *true* by default
 - `fixed` - (optional) enables/disables the ability to fix the text of the item with the specified `distance` value, *false* by default
-- `hidden` - (optional) defines whether the text will be hidden, *false* by default 
+- `hidden` - (optional) defines whether the text will be hidden, *false* by default
 - `fill` - (optional) the background color of the line title item
 - `fontSize` - (optional) the size of the font, 14 by default
 - `lineHeight` - (optional) the height of the text line, 14 by default

--- a/docs/line_titles/index.md
+++ b/docs/line_titles/index.md
@@ -1,5 +1,5 @@
 ---
-sidebar_label: LineTitles 
+sidebar_label: LineTitles
 title: LineTitles
 description: You can learn about Lines in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Diagram.
 ---
@@ -8,7 +8,7 @@ description: You can learn about Lines in the documentation of the DHTMLX JavaSc
 
 ## Overview
 
-Line titles set texts for lines that connect shapes. You can add a text for a line both in the diagram and in the editor by double-clicking on a line or use a toolbar of a line in the editor (click a line to activate). Use double-clicking also for editing line titles both in the diagram and in the editor.
+Line titles set text for lines that connect shapes. You can add text to a line both in the diagram and in the editor by double-clicking on the line, or by using the line's toolbar in the editor (click a line to activate it). You can also use double-clicking to edit line titles both in the diagram and in the editor.
 
 Another way to add a text to a line and manipulate it is to prepare a [data set](guides/loading_data.md#preparing-data-to-load).
 
@@ -73,7 +73,7 @@ See [the full list of configuration properties of a line title object](line_titl
 
 ### Blocking line titles adding
 
-If you need to prevent adding of line titles, you can make use of the [`beforeAdd`](api/data_collection/beforeadd_event.md) event of DataCollection:
+If you need to prevent adding line titles, you can use the [`beforeAdd`](api/data_collection/beforeadd_event.md) event of DataCollection:
 
 ~~~jsx {5}
 const editor= new dhx.DiagramEditor("editor_container", {
@@ -85,7 +85,7 @@ editor.diagram.data.events.on("beforeAdd", (item) => item.type !== "lineTitle");
 
 ### Iterating over line titles
 
-It is possible to iterate over line titles as child items of lines with the help of the [`eachChild()`](api/data_collection/eachchild_method.md) method of DataCollection:
+You can iterate over line titles as child items of lines with the help of the [`eachChild()`](api/data_collection/eachchild_method.md) method of DataCollection:
 
 ~~~jsx {7-9,11-13}
 const editor= new dhx.DiagramEditor("editor_container", {
@@ -103,4 +103,4 @@ editor.diagram.data.eachChild("line_1", (child) => {
 });
 ~~~
 
-You need to pass the id of the line the titles of which should be iterated over as a first parameter. In the above example the callback function will be applied to each child of the specified line and return their ids.
+Pass the id of the line whose titles should be iterated over as the first parameter. In the above example, the callback function will be applied to each child of the specified line and return their ids.

--- a/docs/lines/configuration_properties.md
+++ b/docs/lines/configuration_properties.md
@@ -1,5 +1,5 @@
 ---
-sidebar_label: Line properties 
+sidebar_label: Line properties
 title: Line Properties
 description: You can learn about the Line properties in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Diagram.
 ---
@@ -7,7 +7,7 @@ description: You can learn about the Line properties in the documentation of the
 # Line properties
 
 :::note
-While specifying color values of the item, use the HEX format.
+Specify color values in the HEX format.
 :::
 
 ## Common properties
@@ -18,7 +18,7 @@ While specifying color values of the item, use the HEX format.
 const data = [
     // line object
     {
-        type: "line" | "dash", 
+        type: "line" | "dash",
         id?: string | number,
         from?: string | number,
         to?: string | number,
@@ -147,7 +147,7 @@ For example:
 }
 
 // diagram.data.getItem("$link:1");
-~~~ 
+~~~
 :::
 
 ### Example
@@ -174,7 +174,7 @@ const dataset = {
 
 **Change log**:
 
-- The `links` type of connectors used in the PERT mode of Diagram are added in v6.1
+- The `links` type of connectors used in the PERT mode of Diagram was added in v6.1
 - The `title` property of the `line` object was deprecated in v6.0
 
 **Related articles**: [Configuring lines](/lines/)

--- a/docs/lines/index.md
+++ b/docs/lines/index.md
@@ -1,5 +1,5 @@
 ---
-sidebar_label: Lines 
+sidebar_label: Lines
 title: Lines
 description: You can learn about Lines in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Diagram.
 ---
@@ -14,7 +14,7 @@ The look and feel of the lines which connect shapes is defined by the mode you i
 
 In the default mode of Diagram, various shapes can be connected by ["straight" (by default) or "elbow"](lines/configuration_properties.md) lines in the necessary sequence to make up a scheme of a particular process.
 
-To add a text for a line in the default mode of Diagram/Diagram Editor, use the `text` property of the [lineTitle](/line_titles/) object.
+To add text to a line in the default mode of Diagram/Diagram Editor, use the `text` property of the [lineTitle](/line_titles/) object.
 
 <iframe src="https://snippet.dhtmlx.com/e6zm6wh1?mode=result" frameborder="0" class="snippet_iframe" width="100%" height="650"></iframe>
 
@@ -24,7 +24,7 @@ The org chart mode of Diagram represents an organizational chart that contains a
 
 <iframe src="https://snippet.dhtmlx.com/98tzmzpg?mode=result" frameborder="0" class="snippet_iframe" width="100%" height="650"></iframe>
 
-It is possible to define vertical direction of connecting shapes for the parent shape via the `dir: "vertical"` configuration attribute of the shape object.
+You can define the vertical direction of connecting shapes for the parent shape via the `dir: "vertical"` configuration attribute of the shape object.
 
 ### Lines in the mindmap mode
 
@@ -46,7 +46,7 @@ The PERT mode of Diagram is intended for rendering sequences of tasks and projec
 
 ## Setting connections between shapes
 
-To connect shapes in Diagram, you can apply one of the following two ways:
+To connect shapes in Diagram, you can use one of the following two ways:
 
 - **using line objects**
 
@@ -68,7 +68,7 @@ const data = [
 ];
 ~~~
 
-The `type` property specified in the line object allows you to specify individual type for a separate line.
+The `type` property in the line object lets you set an individual type for each line.
 
 :::note
 See [the full list of configuration properties of a line object](lines/configuration_properties.md).

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -51,7 +51,7 @@ editor.setViewMode("preview"); // "preview" or "edit"
 const editor = new dhx.DiagramEditor("editor_container");
 editor.parse(data);
 
-editor.view.hide("shapebar"); 
+editor.view.hide("shapebar");
 editor.view.hide("editbar");
 ~~~
 
@@ -68,7 +68,7 @@ const editor = new dhx.DiagramEditor("editor_container", {
 Instead, use the following syntax:
 
 ~~~jsx title="From v6.0"
-editor.diagram.config.margin.x = 40; 
+editor.diagram.config.margin.x = 40;
 ~~~
 
 - The `editMode` property of Diagram Editor is deprecated and no longer supported. Instead, use the corresponding property of the `view` object ([toolbar](api/diagram_editor/toolbar/api_overview.md), [shapebar](api/diagram_editor/shapebar/api_overview.md), [editbar](api/diagram_editor/editbar/api_overview.md)).
@@ -93,7 +93,7 @@ const editor = new dhx.DiagramEditor("editor_container", {
 
 ~~~jsx {2-4} title="Before v6.0"
 const editor = new dhx.DiagramEditor("editor_container", {
-    controls: { 
+    controls: {
         // ...
     }
 });
@@ -134,7 +134,7 @@ const editor = new dhx.DiagramEditor("editor_container", {
 const editor = new dhx.DiagramEditor("editor_container", {
     shapeSections: {
         "Swimlane": [{ swimlane: true }],
-        "Groups": [{ group: true }],   
+        "Groups": [{ group: true }],
         "Flowchart shapes": [{ flowShapes: true }],
         "Org shapes, text, topic": [{ org: true }, "text", "topic"]
     }
@@ -148,7 +148,7 @@ const editor = new dhx.DiagramEditor("editor_container", {
         shapebar: {
             sections: {
                 "Swimlane": [{ swimlane: true }],
-                "Groups": [{ group: true }],   
+                "Groups": [{ group: true }],
                 "Flowchart shapes": [{ flowShapes: true }],
                 "Org shapes, text, topic": [{ org: true }, "text", "topic"]
             }
@@ -220,8 +220,8 @@ The names of the [service elements](guides/diagram_editor/toolbar.md#service-ele
 - The `properties` property of the [`addShape`](api/diagram/addshape_method.md) method is deprecated and no longer used. The configuration of a custom shape in the editbar of the Editor is implemented via the [`properties`](api/diagram_editor/editbar/config/properties_property.md) property of the Editbar panel:
 
 ~~~jsx {13-16} title="Before v6.0"
-const editor = new dhx.DiagramEditor("editor_container", { 
-    type: "default"  
+const editor = new dhx.DiagramEditor("editor_container", {
+    type: "default"
 });
 editor.parse(data);
 
@@ -236,7 +236,7 @@ editor.diagram.addShape("network", {
         { type:"arrange" },
         { type:"size" }
     ]
-});   
+});
 ~~~
 
 ~~~jsx {14-27} title="From v6.0"
@@ -293,12 +293,12 @@ editor.diagram.addShape("network", {
 
 ### Diagram Selection API
 
-- The `getId()` method of the Selection object of Diagram is deprecated and no longer supported. Instead you can use the [`getIds()`](api/selection/getids_method.md) and [`getItem()`](api/selection/getitem_method.md) methods of the Selection object. Check the examples below:
+- The `getId()` method of the Selection object of Diagram is deprecated and no longer supported. Instead, you can use the [`getIds()`](api/selection/getids_method.md) and [`getItem()`](api/selection/getitem_method.md) methods of the Selection object. Check the examples below:
 
 ~~~jsx {7} title="Before v6.0"
 // diagram must be created with the "select:true" option
-const diagram = new dhx.Diagram("diagram_container", { 
-    select: true 
+const diagram = new dhx.Diagram("diagram_container", {
+    select: true
 });
 diagram.data.parse(data);
 
@@ -307,8 +307,8 @@ const id = diagram.selection.getId(); // -> "2"
 
 ~~~jsx {7-11} title="From v6.0"
 // a diagram must be created with the "select:true" option
-const diagram = new dhx.Diagram("diagram_container", { 
-    select: true 
+const diagram = new dhx.Diagram("diagram_container", {
+    select: true
 });
 diagram.data.parse(data);
 
@@ -323,9 +323,9 @@ The usage of the `text` property of the [Shape configuration object](shapes/conf
 
 ### Line titles
 
-The titles of Lines are moved from the `line` objects to the common data structure on the same level with Lines and defined as [`lineTitles`](/line_titles/) objects.
+Line titles are moved from the `line` objects to the common data structure at the same level as lines and defined as [`lineTitles`](/line_titles/) objects.
 
-Before v6.0 titles of lines have been specified inside the `line` object as follows:
+Before v6.0, line titles were specified inside the `line` object as follows:
 
 ~~~jsx title="Before v6.0"
 const data = [
@@ -383,7 +383,7 @@ const data = [
         type: "lineTitle",
         id?: string | number,
         text: string,
-        parent: string | number, 
+        parent: string | number,
 
         distance?: number, // 50 by default
         autoPosition?: boolean, // true by default
@@ -416,14 +416,14 @@ Due to the modifications in the Diagram editor interface, the locale settings ha
 The `lineGap` property of Diagram is deprecated and no longer supported. Instead, use the `lineGap` parameter of the [lineConfig](api/diagram/lineconfig_property.md) property.
 
 ~~~jsx {3} title="Before v5.0"
-const diagram = new dhx.Diagram("diagram_container", { 
+const diagram = new dhx.Diagram("diagram_container", {
     type: "default",
     lineGap: 30
 });
 ~~~
 
 ~~~jsx {3-5} title="From v5.0"
-const diagram = new dhx.Diagram("diagram_container", { 
+const diagram = new dhx.Diagram("diagram_container", {
     type: "default",
     lineConfig: {
         lineGap: 30
@@ -457,18 +457,18 @@ const editor = new dhx.DiagramEditor("editor_container", {
 
 ### Diagram API
 
-In v4.2, the `defaultLinkType` property is deprecated. 
+In v4.2, the `defaultLinkType` property is deprecated.
 
 Starting from v4.2, you need to apply the new [lineConfig](api/diagram/lineconfig_property.md) property to specify the default type for connector lines.
 
 ~~~jsx title="Before v4.2"
-const diagram = new dhx.Diagram("diagram_container", { 
+const diagram = new dhx.Diagram("diagram_container", {
     defaultLinkType: "dash"
 });
 ~~~
 
 ~~~jsx {2-4} title="From v4.2"
-const diagram = new dhx.Diagram("diagram_container", { 
+const diagram = new dhx.Diagram("diagram_container", {
     lineConfig: {
         lineType: "dash",
     },
@@ -559,15 +559,15 @@ editor.events.on("AfterShapeMove", (e) => {
 
 The way of creating custom shapes has been changed, simplified and improved.
 
-Starting from v3.0, in order to create your own types of shapes, the new `addShape` method should be used instead of the *diagram.flowShapes* object. The method provides you with the ability to create HTML templates that will work in different browsers. Besides, the method allows creating and editing custom shapes in Diagram Editor.
+Starting from v3.0, to create your own types of shapes, the new `addShape` method should be used instead of the *diagram.flowShapes* object. The method provides you with the ability to create HTML templates that will work in different browsers. Besides, the method allows creating and editing custom shapes in Diagram Editor.
 
-Despite the *diagram.flowShapes* object has been deprecated, it will still continue working.
+Although the *diagram.flowShapes* object has been deprecated, it will continue to work.
 
 ### Toolbar buttons in Editor
 
-Before version 3.0 you were able to show/hide toolbar buttons in Diagram Editor via the related *showApply, showReset, showExport* configuration properties of the Editor.
+Before version 3.0, you were able to show/hide toolbar buttons in Diagram Editor via the related *showApply, showReset, showExport* configuration properties of the Editor.
 
-In the version 3.0 these properties are deprecated and removed. Instead, the `controls` config property that contains a set of *control_name:value* pairs is added. Thus, the properties are replaced with:
+In version 3.0, these properties are deprecated and removed. Instead, the `controls` config property that contains a set of *control_name:value* pairs is added. Thus, the properties are replaced with:
 
 - showApply -> controls.apply
 - showReset -> controls.reset
@@ -575,7 +575,7 @@ In the version 3.0 these properties are deprecated and removed. Instead, the `co
 
 ~~~jsx
 const editor = new dhx.DiagramEditor("editor_container", {
-    controls: { 
+    controls: {
         apply: false,
         reset: false,
         export: true
@@ -604,9 +604,9 @@ See the full list of the available controls in the [Toolbar](guides/diagram_edit
 - diagram.eachItem -> [diagram.data.map](api/data_collection/map_method.md)
 - diagram.getItem -> [diagram.data.getItem](api/data_collection/getitem_method.md)
 - diagram.getSelectedId -> `diagram.selection.getId`
-- diagram.load -> [diagram.data.load](api/data_collection/load_method.md) 
+- diagram.load -> [diagram.data.load](api/data_collection/load_method.md)
 - diagram.parse -> [diagram.data.parse](api/data_collection/parse_method.md)
 - diagram.selectItem -> [diagram.selection.add](api/selection/add_method.md)
 - diagram.serialize -> [diagram.data.serialize](api/data_collection/serialize_method.md)
 - diagram.unselectItem -> [diagram.selection.remove](api/selection/remove_method.md)
-- diagram.updateItem -> [diagram.data.update](api/data_collection/update_method.md) 
+- diagram.updateItem -> [diagram.data.update](api/data_collection/update_method.md)

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,6 +1,6 @@
 ---
-sidebar_label: Diagram overview 
-title: Diagram Overview 
+sidebar_label: Diagram overview
+title: Diagram Overview
 slug: /
 description: You can have an overview of DHTMLX JavaScript Diagram library in the documentation. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Diagram.
 ---
@@ -26,7 +26,7 @@ You can choose shapes of desired types, link them by suitable connectors and bui
 
 ### Custom shapes
 
-You can easily create [your own templates of shapes](shapes/custom_shape.md) and use them to design any diagram you need. For example, it is possible to create such famous types of custom diagrams as:
+You can create [your own templates of shapes](shapes/custom_shape.md) and use them to design any diagram you need. For example, you can create such well-known custom diagrams as:
 
 | [Life Cycle Diagram](https://snippet.dhtmlx.com/y4k51owl) | [Venn Diagram template](https://snippet.dhtmlx.com/2tzyfois) | [UML Class Diagram template](https://snippet.dhtmlx.com/madymxt5) |
 | --------------------------------------------------------- | --------------------------------------------------- | -------------------------------------------------------- |
@@ -38,7 +38,7 @@ You can easily create [your own templates of shapes](shapes/custom_shape.md) and
 
 ### Groups
 
-You can draw simple or more complicated schemes by grouping shapes in different ways with the help of such an element of Diagram as a group. It is possible to create as one-level groups as nested groups, to configure their appearance and behavior. Check the details in the [Groups](/groups/) article.
+You can draw simple or more complicated schemes by grouping shapes in different ways with the help of such an element of Diagram as a group. You can create both one-level and nested groups, and configure their appearance and behavior. Check the details in the [Groups](/groups/) article.
 
 | [Diagram Editor. Default mode. Virtual private cloud architecture](https://snippet.dhtmlx.com/0hf8ahrb) |
 | ------------------------------------------------------------------------------------------------ |
@@ -46,7 +46,7 @@ You can draw simple or more complicated schemes by grouping shapes in different 
 
 ### Swimlanes
 
-Usage of swimlanes of the DHTMLX Diagram library lets you represent any process (be it a business process, manufacturing or service one, and any other processes) or its separate parts from start to finish. Check the details in the [Swimlanes](/swimlanes/) article.
+Swimlanes in the DHTMLX Diagram library let you represent any process (business, manufacturing, service, or any other) or its separate parts from start to finish. Check the details in the [Swimlanes](/swimlanes/) article.
 
 | [Diagram. Default mode. Swimlane template](https://snippet.dhtmlx.com/z6x5m3gb) |
 | ------------------------------------------------------------------------------- |
@@ -54,7 +54,7 @@ Usage of swimlanes of the DHTMLX Diagram library lets you represent any process 
 
 ### Line titles
 
-The titles of Lines are enabled in the default mode of Diagram. You can add the text by double-clicking on a line. Use double-clicking also for editing the text. Check the details in the [LineTitles](/line_titles/) article.
+Line titles are enabled in the default mode of Diagram. You can add text by double-clicking on a line. You can also use double-clicking to edit the text. Check the details in the [LineTitles](/line_titles/) article.
 
 <iframe src="https://snippet.dhtmlx.com/e6zm6wh1?mode=result" frameborder="0" class="snippet_iframe" width="100%" height="600"></iframe>
 
@@ -80,7 +80,7 @@ The partner shapes are very useful for building a family tree.
 
 **Related sample**: [Diagram editor. Org chart mode. Family tree](https://snippet.dhtmlx.com/5pfybpmz)
 
-Here are examples of how the connections of parent shapes look like with one, two, three, and four partners.
+Here are examples of how the connections of parent shapes look with one, two, three, and four partners.
 
 | One partner                               | Two  partners                              |
 | ----------------------------------------- | ------------------------------------------ |
@@ -116,7 +116,7 @@ An example of adding a custom template into the mindmap mode of the diagram to c
 
 ## Diagram in the PERT mode
 
-The [PERT mode](api/diagram/type_property.md) is used to visualize tasks and projects' sequences and connections between them. It is also useful for identifying the critical path and project planning. 
+The [PERT mode](api/diagram/type_property.md) is used to visualize tasks and projects' sequences and connections between them. It is also useful for identifying the critical path and project planning.
 
 Diagram in the PERT mode [uses the DHTMLX Gantt data structure](guides/loading_data.md#data-structure-of-diagram-in-the-pert-mode), which provides [easy interaction between the components](#integrating-pert-diagram-and-dhtmlx-gantt). On loading a Gantt dataset, a Diagram in the PERT mode automatically arranges tasks and projects based on the connections between them.
 
@@ -124,23 +124,23 @@ Diagram in the PERT mode [uses the DHTMLX Gantt data structure](guides/loading_d
 
 ### Integrating PERT Diagram and DHTMLX Gantt
 
-An example of integrating a Diagram in the PERT mode and a Gantt chart is given below: 
+An example of integrating a Diagram in the PERT mode and a Gantt chart is given below:
 
-<iframe src="https://snippet.dhtmlx.com/gcnx4a9h?mode=result" frameborder="0" class="snippet_iframe" width="100%" height="600"></iframe>                                						
+<iframe src="https://snippet.dhtmlx.com/gcnx4a9h?mode=result" frameborder="0" class="snippet_iframe" width="100%" height="600"></iframe>
 
 ## Shape search
 
-DHTMLX Diagram provides you with a set of API that you can apply in order to make working with a Diagram more convenient.
-For example, you can implement a feature of searching a shape on request that helps you to simplify work with large diagrams.
+DHTMLX Diagram provides you with a set of API that you can apply to make working with a Diagram more convenient.
+For example, you can implement a shape search feature that helps you simplify work with large diagrams.
 
 <iframe src="https://snippet.dhtmlx.com/d7kvzq4r?mode=result" frameborder="0" class="snippet_iframe" width="100%" height="600"></iframe>
 
 ## Diagram scale
 
-You can apply the zoom template to your diagram to be able to change its appearance via zooming the diagram in or out. Besides, you can make it possible to user to get the detailed information on the selected shape.
+You can apply the zoom template to your diagram to change its appearance by zooming in or out. You can also let the user get detailed information on the selected shape.
 
 <iframe src="https://snippet.dhtmlx.com/09o8t3o2?mode=result" frameborder="0" class="snippet_iframe" width="100%" height="600"></iframe>
 
 ## What's next
 
-Now you can learn about using DHTMLX Diagram Editor in your application. Read the [Diagram Editor overview](editor_overview.md) to get more about this tool.
+Now you can learn about using DHTMLX Diagram Editor in your application. Read the [Diagram Editor overview](editor_overview.md) to learn more about this tool.

--- a/docs/shapes/configuration_properties.md
+++ b/docs/shapes/configuration_properties.md
@@ -1,13 +1,13 @@
 ---
-sidebar_label: Shape properties 
+sidebar_label: Shape properties
 title: Shape Properties
 description: You can learn about the Shape properties in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Diagram.
 ---
 
 # Shape properties
 
-:::note 
-While specifying color values of the item, use the HEX format.
+:::note
+Specify color values in the HEX format.
 :::
 
 ## Common properties
@@ -18,7 +18,7 @@ While specifying color values of the item, use the HEX format.
 const data = [
     // shape object
     {
-        type: string, 
+        type: string,
         id?: string | number,
         x?: number, // required in the default mode of Diagram
         y?: number, // required in the default mode of Diagram
@@ -46,7 +46,7 @@ Each shape object can include the following properties:
 - `height` - (optional) the height of a shape
 - `width` - (optional) the width of a shape
 - `fixed` - (optional) enables/disables movement and resizing of a shape, *false* by default
-- `hidden` - (optional) defines, whether a shape will be hidden
+- `hidden` - (optional) defines whether a shape will be hidden
 
 :::note
 The values of the `height` and `width` are calculated automatically for a `"text"`/`"topic"` shape, depending on the content of the shape.
@@ -170,11 +170,11 @@ When preparing a data set for shapes to load into the diagram in the org chart m
 - `dx` - (optional) the left offset of the shape
 - `dy` - (optional) the top offset of the shape
 - `dir` - (optional) the direction of shapes connecting. To connect shapes vertically, set the attribute to the `"vertical"` value
-- `open` - (optional) defines, whether the child items of the current shape will be shown; *true* by default
-- `assistant` - (optional) defines, whether the shape is an assistant item for the parent shape
-- `partner` - (optional) defines, whether the shape is a partner item for the parent shape
-- `catchItem` - (optional) defines, whether the item can catch the moving item
-- `giveItem` - (optional) defines, whether the item can be moved
+- `open` - (optional) defines whether the child items of the current shape will be shown; *true* by default
+- `assistant` - (optional) defines whether the shape is an assistant item for the parent shape
+- `partner` - (optional) defines whether the shape is a partner item for the parent shape
+- `catchItem` - (optional) defines whether the item can catch the moving item
+- `giveItem` - (optional) defines whether the item can be moved
 
 ### Example
 
@@ -238,12 +238,12 @@ When preparing a data set for shapes to load into the diagram in the mindmap mod
 - `parent` - (optional) the id of the parent shape
 - `dx` - (optional) the left offset of the shape
 - `dy` - (optional) the top offset of the shape
-- `open` - (optional) defines, whether the child items of the current shape will be shown; *true* by default
+- `open` - (optional) defines whether the child items of the current shape will be shown; *true* by default
 - `openDir` - (optional) shows/hides the child items of the root shape. The object takes two attributes:
     - `left` - (optional) shows/hides the child items to the left of the root shape
     - `right` - (optional) shows/hides the child items to the right of the root shape
-- `catchItem` - (optional) defines, whether the item can catch the moving item
-- `giveItem` - (optional) defines, whether the item can be moved
+- `catchItem` - (optional) defines whether the item can catch the moving item
+- `giveItem` - (optional) defines whether the item can be moved
 
 **Related sample**: [Diagram editor. Mindmap mode. Emotions mind map](https://snippet.dhtmlx.com/lo1vm0e8)
 
@@ -273,7 +273,7 @@ const data = [
         id: "3",
         text: "3",
         parent: "1",
-        catchItem: false 
+        catchItem: false
     },
     {
         id: "4",
@@ -412,7 +412,7 @@ When preparing a data set for `"img-card"` shapes, you can add the following pro
 
 ### Example
 
-~~~jsx 
+~~~jsx
 const data = [
     {
         "id": "1",
@@ -429,7 +429,7 @@ const data = [
         "title": "Emma Lynch",
         "img": "../img/avatar-02.png",
         "parent": "1",
-        "headerColor": "#5874CD" 
+        "headerColor": "#5874CD"
     }
 ];
 ~~~
@@ -466,14 +466,14 @@ When preparing a data set for `"task"` shapes, you can add the following propert
 
 ### Example
 
-~~~jsx 
+~~~jsx
 const data = [
-    { 
-        "id": "4.2.1", 
-        "text": "Functional Testing", 
-        "type": "task", 
-        "parent": "4.2", 
-        "start_date": new Date(2026, 1, 18) 
+    {
+        "id": "4.2.1",
+        "text": "Functional Testing",
+        "type": "task",
+        "parent": "4.2",
+        "start_date": new Date(2026, 1, 18),
         "duration": 2
     }
 ];
@@ -505,14 +505,14 @@ When preparing a data set for `"milestone"` shapes, you can add the following pr
 
 ### Example
 
-~~~jsx 
+~~~jsx
 const data = [
-     { 
-        "id": "5.2", 
-        "text": "Product Launch", 
-        "type": "milestone", 
-        "parent": "5", 
-        "start_date": new Date(2026, 2, 1), 
+     {
+        "id": "5.2",
+        "text": "Product Launch",
+        "type": "milestone",
+        "parent": "5",
+        "start_date": new Date(2026, 2, 1),
         "duration": 1
     }
 ];

--- a/docs/shapes/custom_shape.md
+++ b/docs/shapes/custom_shape.md
@@ -6,9 +6,9 @@ description: You can learn about the Custom Shape in the documentation of the DH
 
 # Custom shape
 
-If the default shapes don't meet your needs, you can create your custom shape.
+If the default shapes don't meet your needs, you can create a custom shape.
 
-Let's imagine, you want to create a new `networkCard` shape which should render an image, text, and IP address.
+Let's imagine you want to create a new `networkCard` shape that renders an image, text, and an IP address.
 
 <iframe src="https://snippet.dhtmlx.com/u1xqyo9w?mode=result" frameborder="0" class="snippet_iframe" width="100%" height="650"></iframe>
 
@@ -59,12 +59,12 @@ const networkDiagram = [
 ]
 ~~~
 
-To change the default values of the *text* and *ip* properties, we've specified the same properties with the new values in the configuration object of a shape. 
+To change the default values of the *text* and *ip* properties, we've specified the same properties with the new values in the configuration object of a shape.
 Thus, the *"Network Card"* text value will be replaced with the *"Remote expert desktop"* one and the *"138.68.41.78"* ip value will be replaced with *"192.168.32.2"*.
 
 ## Event handlers for custom shapes
 
-You may need to add handlers to the events occurred when the user interacts with custom shapes. It can be done by adding event handlers to HTML elements of the template of a shape via the `eventHandlers` attribute of the [`addShape()`](api/diagram/addshape_method.md) method. 
+You may need to add handlers to the events that occur when the user interacts with custom shapes. It can be done by adding event handlers to HTML elements of the template of a shape via the `eventHandlers` attribute of the [`addShape()`](api/diagram/addshape_method.md) method.
 
 In the example below, a context menu will be opened after the user clicks on the icon with the `toggle_container` class:
 
@@ -72,7 +72,7 @@ In the example below, a context menu will be opened after the user clicks on the
 
 The `eventHandlers` object includes a set of *key:value* pairs, where:
 
-- *key* - the name of the event. Note, that at the beginning of the event name the `'on'` prefix is used (onclick, onmouseover).
+- *key* - the name of the event. Note that the `'on'` prefix is used at the beginning of the event name (onclick, onmouseover).
 - *value* - an object that contains a *key:value* pair, where *key* is the css class name that the handler will be applied to and *value* is a function that takes two parameters:
 	- `event` - an event object
 	- `shape` - the shape object

--- a/docs/shapes/default_shapes.md
+++ b/docs/shapes/default_shapes.md
@@ -6,13 +6,13 @@ description: You can learn about the Basic sets of shapes in the documentation o
 
 # Basic sets of shapes
 
-The DHTMLX Diagram library provides you with sets of shapes that you can use to build your diagram. Each Diagram mode: [default](#shapes-in-the-default-mode), [org chart](#shapes-in-the-org-chart-mode), [mindmap](#shapes-in-the-mindmap-mode) and [PERT](#shapes-in-the-pert-mode) has a *basic set* of shapes' types. 
+The DHTMLX Diagram library provides you with sets of shapes that you can use to build your diagram. Each Diagram mode: [default](#shapes-in-the-default-mode), [org chart](#shapes-in-the-org-chart-mode), [mindmap](#shapes-in-the-mindmap-mode) and [PERT](#shapes-in-the-pert-mode) has a *basic set* of shapes' types.
 
 :::tip
 You can add a shape of any type into a diagram initialized in any mode. Use the name of the necessary shape as a value of the `type` attribute inside the shape object, while [preparing a data set for loading into the diagram](guides/loading_data.md#preparing-data-to-load).
 :::
 
-See [the full list of configuration properties of a shape object](shapes/configuration_properties.md). 
+See [the full list of configuration properties of a shape object](shapes/configuration_properties.md).
 
 ## Shapes in the default mode
 
@@ -20,7 +20,7 @@ In the `default` mode of Diagram, the basic set includes **flow chart** shapes. 
 
 ![](/img/flowshapes_types.png)
 
-There is also the `"text"` item that presents a simple text that can be used in a diagram as a shape and connected with other shapes. 
+There is also the `"text"` item that represents simple text that can be used in a diagram as a shape and connected to other shapes.
 
 ![](/img/text_item.png)
 
@@ -36,7 +36,7 @@ Check the configuration properties specific for [shapes in the `default` Diagram
 
 ## Shapes in the org chart mode
 
-In the **org chart** mode of Diagram, the basic set includes two types of shapes: `"card"` and `"img-card"`. 
+In the **org chart** mode of Diagram, the basic set includes two types of shapes: `"card"` and `"img-card"`.
 
 Each shape with the `"card"` type has a text and a colored header line. Shapes located on the same level have headers of identical color. Examples of `"card"` shapes are shown in the diagram of the org chart type below:
 
@@ -70,7 +70,7 @@ Check the configuration properties specific for [shapes in the `mindmap` Diagram
 ## Shapes in the PERT mode
 
 The basic types of shapes in the **PERT** mode of Diagram are:
-    
+
 - the `"task"` type - a shape that has a header and renders dates and duration:
 
 ![](/img/pert_task_shape.png)
@@ -79,7 +79,7 @@ The basic types of shapes in the **PERT** mode of Diagram are:
 
 ![](/img/pert_milestone_shape.png)
 
-- the `"project"` type - a container used to [group the shapes of the `"task"` and `"milestone"` types](/groups/#grouping-shapes-in-the-pert-mode): 
+- the `"project"` type - a container used to [group the shapes of the `"task"` and `"milestone"` types](/groups/#grouping-shapes-in-the-pert-mode):
 
 ![](/img/pert_project_group.png)
 
@@ -110,11 +110,11 @@ See [the full list of configuration properties of a shape object](shapes/configu
 
 ### Setting the default shape type
 
-It is also possible to set the default type for all the shapes via the [`defaultShapeType`](api/diagram/defaultshapetype_property.md) attribute of the diagram config object:
+You can also set the default type for all the shapes via the [`defaultShapeType`](api/diagram/defaultshapetype_property.md) attribute of the diagram config object:
 
 ~~~jsx
 const diagram = new dhx.Diagram("diagram_container", {
-    type: "default", // type: "org" | type: "mindmap" | type: "pert"  
+    type: "default", // type: "org" | type: "mindmap" | type: "pert"
     defaultShapeType: "rectangle"
 });
 diagram.data.parse(data);

--- a/docs/swimlanes/configuration_properties.md
+++ b/docs/swimlanes/configuration_properties.md
@@ -1,5 +1,5 @@
 ---
-sidebar_label: Swimlane properties 
+sidebar_label: Swimlane properties
 title: Swimlane and Swimlane Cell Properties
 description: You can learn about the Swimlane and Swimlane cell properties in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Diagram.
 ---
@@ -7,7 +7,7 @@ description: You can learn about the Swimlane and Swimlane cell properties in th
 # Swimlane and swimlane cell properties
 
 :::note
-While specifying color values of the item, use the HEX format.
+Specify color values in the HEX format.
 :::
 
 ## Properties of a swimlane
@@ -124,14 +124,14 @@ The `open` property works when a `header` is initialized with the `closable` att
     - `fontColor` - (optional) the color of the text font, "#4C4C4C" by default
     - `fontWeight` - (optional) the text font weight, possible values are: `"normal"`, `"bold"`, `"bolder"`, `"lighter"`, values `"100"`-`"900"`, where `"400"` is the same as normal, and `"600"`+ is the boldest font; `"500"` by default
     - `iconColor` - (optional) the color of the icon of the header, "#808080" by default
-    - `position` - (optional) the positioning of the group header: `"top"` (default) | `"bottom"` | `"left"` | `"right"`
+    - `position` - (optional) the positioning of the swimlane header: `"top"` (default) | `"bottom"` | `"left"` | `"right"`
     - `editable` - (optional) enables/disables the ability to edit the text of the header by double-clicking on it; *true* by default
     - `closable` - (optional) shows/hides an icon intended to expand/collapse a swimlane; *false* by default
-    - `enable` - (optional) shows/hides the header of the group; *true* by default
-- `subHeaderRows` - (optional) an object with configuration settings of the left/right subheaders of the swimlane. The object have the following attributes:
+    - `enable` - (optional) shows/hides the header of the swimlane; *true* by default
+- `subHeaderRows` - (optional) an object with configuration settings of the left/right subheaders of the swimlane. The object has the following attributes:
     - `height` - (optional) the height of the subheaders, 40 by default
     - `position` - (optional) the positioning of the subheaders: `"left"` | `"right"`
-    - `enable` - (optional) shows/hides the subheaders of the group; *true* by default
+    - `enable` - (optional) shows/hides the subheaders of the swimlane; *true* by default
     - `fill` - (optional) the background color of the subheaders
     - `fontSize` - (optional) the size of the font in pixels, 14 by default
     - `lineHeight` - (optional) the height of a line, 14 by default
@@ -155,10 +155,10 @@ The `open` property works when a `header` is initialized with the `closable` att
         - `fontWeight` - (optional) the text font weight, possible values are: `"normal"`, `"bold"`, `"bolder"`, `"lighter"`, values `"100"`-`"900"`, where `"400"` is the same as normal, and `"600"`+ is the boldest font; `"500"` by default
         - `iconColor` - (optional) the color of the icon of the subheader, "#808080" by default
         - `editable` - (optional) enables/disables the ability to edit the text of the subheader by double-clicking on it; *true* by default
-- `subHeaderCols` - (optional) an object with configuration settings of the top/bottom subheaders of the swimlane. The object have the following attribute:
+- `subHeaderCols` - (optional) an object with configuration settings of the top/bottom subheaders of the swimlane. The object has the following attribute:
     - `position` - (optional) the positioning of the subheaders: `"top"` | `"bottom"`
     - the other attributes of `subHeaderCols` are the same as the attributes of `subHeaderRows` (check the details above)
-- `key` - (optional) your own property with your own logic to be implemented under the hood
+- `key` - (optional) a custom property with your own logic, implemented under the hood
 
 ### Example
 
@@ -234,15 +234,15 @@ The configuration properties of a swimlane cell are given below:
 - `groupChildren` - (optional) an array with ids of the first-level child items of a cell
 - `style` - (optional) an object with the style settings of the cell. The object can contain the following properties:
     - `fill` - (optional) the background color of the cell
-    - `overFill` - (optional) the background color of the cell when the user is holding the item and moving it into/outside the cell *providing that no less than 75% of the item's area is inside the cell*
-    - `partiallyFill` - (optional) the background color of the cell when the user is holding the item and moving it into/outside the cell *providing that 75% of the item's area or more is out of the cell and other settings are not defined via the `exitArea` attribute*
+    - `overFill` - (optional) the background color of the cell when the user is holding the item and moving it into/outside the cell *provided that no less than 75% of the item's area is inside the cell*
+    - `partiallyFill` - (optional) the background color of the cell when the user is holding the item and moving it into/outside the cell *provided that 75% of the item's area or more is out of the cell and other settings are not defined via the `exitArea` attribute*
 - `exitArea` - (optional) an object with the settings which will be applied to the item when the user is dragging it out of the cell (*is applied only to the first-level children of the cell*). The object can contain the following attributes:
-    - `groupBehavior` - (optional) the behavior of the child item of the cell when the user is moving it out of the cell: 
+    - `groupBehavior` - (optional) the behavior of the child item of the cell when the user is moving it out of the cell:
         - `"unbound"` (by default) - the user can move an item into or outside the cell
-        - `"boundNoBorderExtension"` - the user can move an item into the cell but cannot drag the item outside the cell if the item has been dropped inside the cell. The item won't expand the borders of the cell when trying to drag the item outside the cell
-    - `padding` - (optional) defines the padding between the cell and the edge of the item when moving the item inside the cell. <br> 
+        - `"boundNoBorderExtension"` - the user can move an item into the cell but cannot drag the item outside the cell if the item has been dropped inside the cell. The item won't expand the borders of the cell when the user tries to drag the item outside the cell
+    - `padding` - (optional) defines the padding between the cell and the edge of the item when moving the item inside the cell. <br>
     :::tip
-    The `padding` attribute is available if *groupBehavior: `"boundNoBorderExtension"`*
+    The `padding` attribute is available if `groupBehavior` is set to `"boundNoBorderExtension"`
     :::
 
 ### Example

--- a/docs/swimlanes/index.md
+++ b/docs/swimlanes/index.md
@@ -1,5 +1,5 @@
 ---
-sidebar_label: Swimlanes 
+sidebar_label: Swimlanes
 title: Swimlanes
 description: You can learn about Swimlanes in the documentation of the DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Diagram.
 ---
@@ -8,7 +8,7 @@ description: You can learn about Swimlanes in the documentation of the DHTMLX Ja
 
 ## Swimlane overview
 
-A swimlane represents a rectangular element of Diagram that consists of cells (or lanes) arranged vertically or horizontally. Each cell (*type: "$sgroup"*) can include child items such as shapes, or groups.
+A swimlane represents a rectangular element of Diagram that consists of cells (or lanes) arranged vertically or horizontally. Each cell (*type: "$sgroup"*) can include child items such as shapes or groups.
 
 :::note
 Swimlanes are available only in the default mode of Diagram/Diagram Editor (type: `"default"`).
@@ -18,7 +18,7 @@ Swimlanes are available only in the default mode of Diagram/Diagram Editor (type
 
 <iframe src="https://snippet.dhtmlx.com/k5vlvj8i?mode=result" frameborder="0" class="snippet_iframe" width="100%" height="700"></iframe>
 
-Swimlanes will help you to visualize any process (be it a business process, manufacturing or service one, and any other processes) or its separate parts from start to finish.
+Swimlanes will help you visualize any process (business, manufacturing, service, or any other) or its separate parts from start to finish.
 
 ## Creating swimlanes
 
@@ -32,7 +32,7 @@ const data = [
         height: 500,
         width: 850,
         // the layout of a swimlane should contain at least one cell
-        layout: [ 
+        layout: [
             [1] // the cell with id:"1" and type:"$sgroup"
         ]
     }
@@ -43,13 +43,13 @@ const diagram = new dhx.Diagram("diagram_container");
 diagram.data.parse(data);
 ~~~
 
-The code example above presents the simplest configuration of a swimlane with default settings (i.e. without a header and subheader).
+The code example above shows the simplest configuration of a swimlane with default settings (i.e. without a header and subheader).
 
 ### Swimlane structure
 
 The structure of a swimlane can be rather different. It is defined via the [layout](swimlanes/configuration_properties.md) configuration property of the swimlane object. The property allows you to arrange the cells of a swimlane into rows and columns.
 
-All you need to do is specify an array with a matrix as a value of the property. The matrix can be either an array:  
+All you need to do is specify an array with a matrix as a value of the property. The matrix can be either an array:
 
 ~~~jsx
 // a swimlane with 3 columns
@@ -64,13 +64,13 @@ or a set of arrays separated by commas:
 // a swimlane with 2 rows and 3 columns
 layout: [
     [1, 2, 3],
-    [4, 5, 6] 
+    [4, 5, 6]
 ]
 ~~~
 
 where:
 
-- each cell in the layout have a unique number;
+- each cell in the layout has a unique number;
 - the number of arrays defines the number of rows (if there are several arrays, the number of cells must be equal in all the arrays);
 - the number of cells in the array defines the number of columns.
 
@@ -90,7 +90,7 @@ const data = [
         id: "main",
         height: 500,
         width: 850,
-        layout: [ 
+        layout: [
             [1, 2, 3]
         ]
     },
@@ -116,19 +116,19 @@ When you specify a unique number for each cell, all the cells will be rendered w
 ~~~jsx
 layout: [
     [1, 2, 3],
-    [4, 5, 6] 
+    [4, 5, 6]
 ]
 ~~~
 
 ![](/img/swimlane_cells.png)
 
-If needed you can group a range of cells and remove a border(s) between them. To do this, choose any cell from the range and replace unique numbers of the cell(s) from the range with the number of this cell.<br>
+If needed, you can group a range of cells and remove the border(s) between them. To do this, choose any cell from the range and replace unique numbers of the cell(s) from the range with the number of this cell.<br>
 Here is an example of grouping first two cells placed in the first row:
 
 ~~~jsx
 layout: [
     [1, 1, 3],
-    [4, 5, 6] 
+    [4, 5, 6]
 ]
 ~~~
 
@@ -160,10 +160,10 @@ const data = [
     // configuring a swimlane
     {
         type: "$swimlane",
-        id: "main"
+        id: "main",
         height: 500,
         width: 850,
-        layout: [ 
+        layout: [
             [1, 2, 3]
         ]
     }
@@ -181,9 +181,9 @@ const data = [
         id: "main",
         height: 500,
         width: 830,
-        layout: [ 
+        layout: [
             // 3 columns
-            [1, 2, 3] 
+            [1, 2, 3]
         ],
         header: {
             position: "left",
@@ -211,7 +211,7 @@ const data = [
         id: "main",
         height: 500,
         width: 830,
-        layout: [ 
+        layout: [
             // 2 rows
             [1, 2, 3],
             [4, 5, 6]

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: What's new
 title: What's New
-description: You can learn a new information about DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Diagram.
+description: You can learn new information about DHTMLX JavaScript Diagram library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Diagram.
 ---
 
 # What's new
@@ -31,7 +31,7 @@ Released on June 17, 2026
 - Diagram Editor. Fixed the bug that caused a shape to be deleted while editing its text
 - Diagram. Fixed a Safari-specific bug where lines with the `backArrow: "filled"` property were not rendered correctly
 
-## Version 6.1.3 
+## Version 6.1.3
 
 Released on May 21, 2026
 
@@ -45,7 +45,7 @@ Released on May 21, 2026
 - Diagram. Fixed the issue where calling [`autoPlace()`](api/diagram/autoplace_method.md) ignored [`fromSide` and `toSide`](lines/configuration_properties.md) link values, ensuring the diagram structure remains consistent
 - Diagram. The `Radial` autoplacement algorithm was refactored to fix the issue with critically large distances between shapes, providing a more compact layout
 
-## Version 6.1.2 
+## Version 6.1.2
 
 Released on April 2, 2026
 
@@ -55,7 +55,7 @@ Released on April 2, 2026
 - Diagram Editor. The issue where pressing the <kbd>Backspace</kbd> key during inline text editing would delete the shape or the line title is fixed
 - Export. A security vulnerability in PDF/PNG export that allowed arbitrary local file access via HTML injection is fixed through improved sanitization and environment hardening
 
-## Version 6.1.1 
+## Version 6.1.1
 
 Released on February 5, 2026
 
@@ -86,12 +86,12 @@ Released on November 25, 2025
 ### Updates
 
 - DataCollection API. Updates for the PERT mode:
-    - the [`parse()`](api/data_collection/parse_method.md) method may take as the first parameter an object with `data` and `links` arrays 
-    - the [`serialize()`](api/data_collection/serialize_method.md) method may return an object with `data` and `links` arrays 
+    - the [`parse()`](api/data_collection/parse_method.md) method may take as the first parameter an object with `data` and `links` arrays
+    - the [`serialize()`](api/data_collection/serialize_method.md) method may return an object with `data` and `links` arrays
 - Diagram API. The ability to set the format of rendering dates in the task shapes for the PERT mode:
     - a new `dateFormat` parameter for the [`typeConfig`](api/diagram/typeconfig_property.md) configuration property
 - Diagram/Diagram Editor API. The ability to define the connection type of the lines:
-    - a new `connectType` parameter for the [`lineConfig`](api/diagram/lineconfig_property.md) configuration property of Diagram 
+    - a new `connectType` parameter for the [`lineConfig`](api/diagram/lineconfig_property.md) configuration property of Diagram
     - a new `connectType` parameter for the [`lineConfig`](api/diagram_editor/editor/config/lineconfig_property.md) configuration property of Diagram Editor
 - Export API. The [`pdf()`](api/export/pdf_method.md) and [`png()`](api/export/png_method.md) export functions return a promise of data export
 
@@ -107,8 +107,8 @@ Released on November 25, 2025
 
 ### New samples
 
-- [Diagram. PERT chart. Initialization](https://snippet.dhtmlx.com/4h5fi7xd) 
-- [Diagram and Gantt. PERT chart. Initialization](https://snippet.dhtmlx.com/409jj9uh)  
+- [Diagram. PERT chart. Initialization](https://snippet.dhtmlx.com/4h5fi7xd)
+- [Diagram and Gantt. PERT chart. Initialization](https://snippet.dhtmlx.com/409jj9uh)
 - [Diagram and Gantt. PERT chart. Full integration](https://snippet.dhtmlx.com/gcnx4a9h)
 - [Diagram and Gantt. PERT chart. Popup window](https://snippet.dhtmlx.com/fvfysbdb)
 - [Diagram and Gantt. PERT chart. Custom shapes and styling (custom CSS)](https://snippet.dhtmlx.com/mtk92awx)
@@ -125,7 +125,7 @@ Released on November 25, 2025
 - [Diagram Editor. Fishbone Diagram. Multiple causes](https://snippet.dhtmlx.com/0dgjwt6u)
 
 
-## Version 6.0.11 
+## Version 6.0.11
 
 Released on June 18, 2025
 
@@ -133,7 +133,7 @@ Released on June 18, 2025
 
 - Diagram Editor. Incorrect shapes moving while zooming in
 
-## Version 6.0.10 
+## Version 6.0.10
 
 Released on March 10, 2025
 
@@ -141,7 +141,7 @@ Released on March 10, 2025
 
 - Diagram. The issue with adjusting the size of the line shape arrow while editing the line width
 
-## Version 6.0.9 
+## Version 6.0.9
 
 Released on February 4, 2025
 
@@ -161,7 +161,7 @@ Released on December 5, 2024
 Released on November 27, 2024
 
 - Diagram Editor. An error occurred during the shape editing with the Editbar
-- Diagram Editor. An issue with a shape moving during the navigation on inline editing 
+- Diagram Editor. An issue with a shape moving during the navigation on inline editing
 
 ## Version 6.0.4
 
@@ -171,7 +171,7 @@ Released on October 1, 2024
 
 - Diagram Editor. Calling the `destructor()` method throws an error
 
-## Version 6.0.3 
+## Version 6.0.3
 
 Released on August 28, 2024
 
@@ -212,7 +212,7 @@ The new update introduces significant changes in the structure and functionality
 ### New functionality
 
 - Restructuring of Diagram Editor: providing the ability to interact with its parts and manage their visibility with the [`view`](api/diagram_editor/editor/config/view_property.md) property that includes the following configurations:
-    - [Toolbar](guides/diagram_editor/toolbar.md) - a top part of Diagram Editor that helps users to control the editing process (see [API overview](api/diagram_editor/toolbar/api_overview.md))
+    - [Toolbar](guides/diagram_editor/toolbar.md) - a top part of Diagram Editor that helps users control the editing process (see [API overview](api/diagram_editor/toolbar/api_overview.md))
     - [Shapebar](guides/diagram_editor/shapebar.md) - (former Left panel) a part of Diagram Editor that renders previews of Diagram items (see [API overview](api/diagram_editor/shapebar/api_overview.md))
     - [Editbar](guides/diagram_editor/editbar.md) - (former Right panel) a part of Diagram Editor that allows users to edit Diagram items (see [API overview](api/diagram_editor/editbar/api_overview.md)). You can perform the following actions:
         - sets of predefined [Basic controls](api/diagram_editor/editbar/basic_controls_overview.md) and [Complex controls](api/diagram_editor/editbar/complex_controls_overview.md)
@@ -316,8 +316,8 @@ Released on May 30, 2023
 - Diagram Editor. Fix the issue with custom points not moving during a multi select move
 - Diagram Editor. Fix the impossibility to link a shape to itself
 - Fix the problem with exporting a default diagram without [exportStyles](api/diagram/exportstyles_property.md)
-- Fix the issue with the promiz.js library that caused an error with the setImmediate() method definition on importing the sources 
-- Fix path formation of the URL in the Export object 
+- Fix the issue with the promiz.js library that caused an error with the setImmediate() method definition on importing the sources
+- Fix path formation of the URL in the Export object
 - Types for export are added
 
 ## Version 5.0.1
@@ -325,7 +325,7 @@ Released on May 30, 2023
 Released on January 19, 2023
 
 ### Fixes
-  
+
 - Diagram Editor. Fix the issue which caused lines not always being drawn in their places if data was exported and then loaded again
     - Now it is possible to define the coordinates for lines in the default mode (new [`points`](lines/configuration_properties.md#properties-specific-for-the-default-mode) property of the line object)
 - Diagram Editor. Fix the issue with dragging of shapes in the grid after changing the zoom level
@@ -360,7 +360,7 @@ The new release introduces some changes to the `lineGap` property. Check the [Mi
     - the **Auto Layout** button of [Toolbar](guides/diagram_editor/toolbar.md) now provides two options for shapes' auto-placement: *Orthogonal* and *Radial*
 - [Snap lines](guides/diagram_editor/grid_area.md#enablingdisabling-snap-lines) for arrangement of shapes in the grid area with greater precision
 - The ability to configure snap lines via the new [`magnetic`](api/diagram_editor/editor/config/magnetic_property.md) property
-- The ability to copy and paste styles of an item(s) via <kbd>Alt</kbd> (<kbd>Option</kbd>) + <kbd>Ctrl</kbd> (<kbd>Cmd</kbd>) + <kbd>С</kbd> => <kbd>Alt</kbd> (<kbd>Option</kbd>) + <kbd>Ctrl</kbd> (<kbd>Cmd</kbd>) + <kbd>V</kbd> (see the **[example](https://snippet.dhtmlx.com/klgvu3jq)**) 
+- The ability to copy and paste styles of an item(s) via <kbd>Alt</kbd> (<kbd>Option</kbd>) + <kbd>Ctrl</kbd> (<kbd>Cmd</kbd>) + <kbd>С</kbd> => <kbd>Alt</kbd> (<kbd>Option</kbd>) + <kbd>Ctrl</kbd> (<kbd>Cmd</kbd>) + <kbd>V</kbd> (see the **[example](https://snippet.dhtmlx.com/klgvu3jq)**)
 - The ability to [align and distribute multiple items](guides/diagram_editor/grid_area.md#aligning-multiple-items)
 - Now tooltips will appear when you hover over controls in the personal toolbar of items
 - Extended list of [locale options](guides/localization.md) for localization of tooltips in the per-item toolbar
@@ -500,7 +500,7 @@ Released on April 15, 2021
 - The ability to customize the personal toolbars for editing items in the [grid area](guides/diagram_editor/grid_area.md) via the [shapeToolbar](api/diagram_editor/editor/config/shapetoolbar_property.md) property of the Editor object
 - New events of the Editor object: [BeforeShapeIconClick](api/diagram_editor/editor/events/beforeshapeiconclick_event.md) and [AfterShapeIconClick](api/diagram_editor/editor/events/aftershapeiconclick_event.md), [BeforeShapeMove](api/diagram_editor/editor/events/beforeshapemove_event.md) and [AfterShapeMove](api/diagram_editor/editor/events/aftershapeiconclick_event.md)
 - The ability to cancel sending CSS styles to the export service via the [exportStyles](api/diagram/exportstyles_property.md) configuration option of the diagram object
-  
+
 ### Updates
 
 - The [type](api/diagram/type_property.md) configuration property of the diagram object is updated: new "default" and "mindmap" values are added
@@ -534,7 +534,7 @@ Released on January 27, 2021
 ### Fixes
 
 - Fix the incorrect behavior of the shape selected in the Editor, which is initialized in the default mode, when working with the input field on the page
-- Fix the issue that caused a collapsed/expanded item not to work with its parent 
+- Fix the issue that caused a collapsed/expanded item not to work with its parent
 - Fix the incorrect work of the [showItem()](api/diagram/showitem_method.md) method when the child item is hidden
 
 ## Version 3.0.3
@@ -577,7 +577,7 @@ The new update introduces some changes and improvements. Check the [Migration](m
 - New [autoPlace()](api/diagram/autoplace_method.md) method and [autoplacement](api/diagram/autoplacement_property.md) property are added for [auto-arranging connected shapes](guides/manipulating_items.md#arranging-shapes-automatically) in the hierarchical structure
 - [Ability to set the default configuration of a shape](guides/diagram/configuration.md#setting-the-default-configuration-of-a-shape) via the `defaults` property when initializing [Diagram](api/diagram/defaults_property.md) or [Diagram Editor](api/diagram_editor/editor/config/defaults_property.md)
 - The [addShape()](api/diagram/addshape_method.md) method for [creating custom shapes](shapes/custom_shape.md) in Diagram and Diagram Editor is added
-- New properties of the Editor object: `controls`, [defaults](api/diagram_editor/editor/config/defaults_property.md), `shapeSections`, `shapeBarWidth`, `scalePreview`, [scale](api/diagram_editor/editor/config/scale_property.md), `gapPreview` 
+- New properties of the Editor object: `controls`, [defaults](api/diagram_editor/editor/config/defaults_property.md), `shapeSections`, `shapeBarWidth`, `scalePreview`, [scale](api/diagram_editor/editor/config/scale_property.md), `gapPreview`
 - The *Grid Step* sidebar option is added to the [right panel of the Editor](guides/diagram_editor/editbar.md)
 - Ability to hide/show any toolbar buttons of the Editor as well as the *Grid Step* sidebar option via the `controls` property of the Editor object
 - Ability [to configure sidebar options for editing attributes of the custom shapes in the right panel of the editor](guides/diagram_editor/editbar.md) via the `properties` attribute of the [addShape()](api/diagram/addshape_method.md) method
@@ -585,7 +585,7 @@ The new update introduces some changes and improvements. Check the [Migration](m
 - [Possibility to customize the appearance of shapes rendered in the left panel of the Editor](guides/diagram_editor/shapebar.md) via the [preview](shapes/configuration_properties.md#properties-specific-for-the-default-mode) property of the shape object
 - Ability [to select, copy, paste, delete, move several shapes in the Editor](guides/diagram_editor/grid_area.md#manipulating-multiple-items)
 - Ability [to select and delete several connector lines](guides/diagram_editor/grid_area.md#manipulating-multiple-items) in the editor which is initialized in the default mode
-- Ability to import data from a JSON file to the Editor via the ["Import Data"](guides/diagram_editor/toolbar.md) button of the toolbar 
+- Ability to import data from a JSON file to the Editor via the ["Import Data"](guides/diagram_editor/toolbar.md) button of the toolbar
 - The [destructor()](api/diagram/destructor_method.md) method is added
 
 ### Updates
@@ -667,10 +667,10 @@ The API structure was totally reorganized and improved to simplify work with it.
 - Ability to [find necessary shapes](guides/manipulating_items.md#finding-the-necessary-item)
 - Ability to [filter shapes by specified criteria](guides/manipulating_items.md#filtering-items)
 - Ability to [add a toolbar with icons for shapes](guides/diagram/configuration.md#setting-toolbar-for-shapes) to simplify interaction with them
-- Enhanced performance 
+- Enhanced performance
 - Ability to adjust to any HTML container and built-in auto-sizing
 
-## Version 1.1 
+## Version 1.1
 
 Released on December 5, 2017
 
@@ -684,7 +684,7 @@ Released on December 5, 2017
 
 - [Extended API](api/diagram/api_overview.md): new methods, properties and events
 
-## Version 1.0 
+## Version 1.0
 
 Released on September 29, 2017
 


### PR DESCRIPTION
- correct subject-verb agreement and broken "as...as" construction
- replace "providing that" with "provided that", fix dangling modifiers
- reduce wordiness and repetition in prose
- normalize API name formatting to backticks
- strip trailing whitespace in docs/groups